### PR TITLE
Add simple gaussian model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ development_scripts/*hdf
 *.session.vim*
 *.env*
 __pycache__/
-test.ipynb
+*ipynb
+!examples/*.ipynb

--- a/alea/examples/gaussian_model.py
+++ b/alea/examples/gaussian_model.py
@@ -1,8 +1,6 @@
 from alea.statistical_model import StatisticalModel
 import scipy.stats as stats
 import numpy as np
-from iminuit import Minuit
-from iminuit.util import make_func_code
 
 
 class GaussianModel(StatisticalModel):

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -1,6 +1,9 @@
 import inspect
 from inference_interface import toydata_from_file, toydata_to_file
 from typing import Tuple
+import numpy as np
+from iminuit import Minuit
+from iminuit.util import make_func_code
 
 class StatisticalModel:
     """


### PR DESCRIPTION
This adds the simplest model, which can serve as a very basic example and for unittests. This closes #5.

You can run the following code to check the functionality:

```python
from alea.examples.gaussian_model import GaussianModel
import matplotlib.pyplot as plt
import numpy as np

# Initialize model
model = GaussianModel(mu=0, sigma=1)

# Generate and set toy
data = model.generate_data()
model.set_data(data)
print(model.get_data(), model.get_data().dtype)

# Fit the data
best_fit, ll_val = model.fit(verbose=True)

# Make a plot of the ll scan
x = np.linspace(-2, 2, 1000)
y = - model.ll(x, 1)
y -=  min(y)
plt.plot(x, y)
mle = best_fit["mu"]
plt.axvline(mle, label=f"MLE={mle:.2f}", color="red")
plt.axvline(model.get_data()["hat_mu"][0],
            label=f"hat_mu={model.get_data()['hat_mu'][0]:.2f}",
            ls=":",
            color="k")
plt.axhline(.5, c="k")
plt.ylim(0)
plt.legend()
plt.xlabel("mu")
plt.ylabel("Log Likelihood Ratio")
```

