### PR TITLE
Removes all hash for parameters not used for each source, and for all…

### DIFF
--- a/alea/blueice_extended_model.py
+++ b/alea/blueice_extended_model.py
@@ -132,7 +132,7 @@ class BlueiceExtendedModel(StatisticalModel):
 
                 # Set rate parameters
                 rate_parameters = [
-                    p for p in source["parameters"] if self.parameters[p].type == "rate"]
+                    p for p in source["parameters"] if self.parameters[p].ptype == "rate"]
                 if len(rate_parameters) != 1:
                     raise ValueError(
                         f"Source {source['name']} must have exactly one rate parameter.")
@@ -146,7 +146,7 @@ class BlueiceExtendedModel(StatisticalModel):
 
                 # Set shape parameters
                 shape_parameters = [
-                    p for p in source["parameters"] if self.parameters[p].type == "shape"]
+                    p for p in source["parameters"] if self.parameters[p].ptype == "shape"]
                 if shape_parameters:
                     # TODO: Implement setting shape parameters
                     raise NotImplementedError("Shape parameters are not yet supported.")

--- a/alea/blueice_extended_model.py
+++ b/alea/blueice_extended_model.py
@@ -155,18 +155,7 @@ class BlueiceExtendedModel(StatisticalModel):
 
                 # Set efficiency parameters
                 if source.get("apply_efficiency", False):
-                    assert "efficiency_name" in source, "Unspecified efficiency_name for source {:s}".format(source["name"])
-                    efficiency_name = source["efficiency_name"]
-                    assert efficiency_name in source["parameters"], "The efficiency_name for source {:s} is not in its parameter list".format(source["name"])
-                    efficiency_parameter = self.parameters[efficiency_name]
-                    assert efficiency_parameter.type == "efficiency", "The parameter {:s} must" \
-                                                                      " be an efficiency".format(efficiency_name)
-                    limits = efficiency_parameter.fit_limits
-                    assert 0 <= limits[0], 'Efficiency parameters including {:s} must be' \
-                                         ' constrained to be nonnegative'.format(efficiency_name)
-                    assert np.isfinite(limits[1]), 'Efficiency parameters including {:s} must be' \
-                                                   ' constrained to be finite'.format(efficiency_name)
-                    ll.add_shape_parameter(efficiency_name, anchors=(limits[0], limits[1]))
+                    self._set_efficiency(source, ll)
 
 
             ll.prepare()
@@ -295,3 +284,18 @@ class CustomAncillaryLikelihood(LogAncillaryLikelihood):
                     "Only float uncertainties are supported at the moment.")
             constraint_functions[name] = func
         return constraint_functions
+
+    def _set_efficiency(self, source, ll):
+        assert "efficiency_name" in source, "Unspecified efficiency_name for source {:s}".format(source["name"])
+        efficiency_name = source["efficiency_name"]
+        assert efficiency_name in source[
+            "parameters"], "The efficiency_name for source {:s} is not in its parameter list".format(source["name"])
+        efficiency_parameter = self.parameters[efficiency_name]
+        assert efficiency_parameter.type == "efficiency", "The parameter {:s} must" \
+                                                          " be an efficiency".format(efficiency_name)
+        limits = efficiency_parameter.fit_limits
+        assert 0 <= limits[0], 'Efficiency parameters including {:s} must be' \
+                               ' constrained to be nonnegative'.format(efficiency_name)
+        assert np.isfinite(limits[1]), 'Efficiency parameters including {:s} must be' \
+                                       ' constrained to be finite'.format(efficiency_name)
+        ll.add_shape_parameter(efficiency_name, anchors=(limits[0], limits[1]))

--- a/alea/blueice_extended_model.py
+++ b/alea/blueice_extended_model.py
@@ -117,10 +117,10 @@ class BlueiceExtendedModel(StatisticalModel):
 
             # add all parameters to extra_dont_hash for each source unless it is used:
             for i, source in enumerate(config["sources"]):
-                parameters_to_ignore: List[str] = [p.name for p in self.parameters if (p.type == "shape")
+                parameters_to_ignore: List[str] = [p.name for p in self.parameters if (p.ptype == "shape")
                                                    & (p.name not in source["parameters"])]
                 # no efficiency affects PDF:
-                parameters_to_ignore += [p.name for p in self.parameters if (p.type == "efficiency")]
+                parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
                 parameters_to_ignore += source.get("extra_dont_hash_settings", [])
 
                 # ignore all shape parameters known to this model not named specifically in the source:
@@ -210,8 +210,8 @@ class BlueiceExtendedModel(StatisticalModel):
         assert efficiency_name in source[
             "parameters"], "The efficiency_name for source {:s} is not in its parameter list".format(source["name"])
         efficiency_parameter = self.parameters[efficiency_name]
-        assert efficiency_parameter.type == "efficiency", "The parameter {:s} must" \
-                                                          " be an efficiency".format(efficiency_name)
+        assert efficiency_parameter.ptype == "efficiency", "The parameter {:s} must" \
+            " be an efficiency".format(efficiency_name)
         limits = efficiency_parameter.fit_limits
         assert 0 <= limits[0], 'Efficiency parameters including {:s} must be' \
                                ' constrained to be nonnegative'.format(efficiency_name)
@@ -296,4 +296,3 @@ class CustomAncillaryLikelihood(LogAncillaryLikelihood):
                     "Only float uncertainties are supported at the moment.")
             constraint_functions[name] = func
         return constraint_functions
-

--- a/alea/blueice_extended_model.py
+++ b/alea/blueice_extended_model.py
@@ -80,9 +80,8 @@ class BlueiceExtendedModel(StatisticalModel):
         for ll in self._likelihood.likelihood_list[:-1]:  # ancillary likelihood does not contribute
 
             ll_pars = list(ll.rate_parameters.keys()) + list(ll.shape_parameters.keys())
+            ll_pars += ["livetime_days"]
             call_args = {k:i for k, i in kwargs.items() if k in ll_pars}
-            if "livetime_days" in kwargs:
-                call_args["livetime_days"] = kwargs["livetime_days"]
 
             mus = ll(full_output=True, **call_args)[1]
             for n, mu in zip(ll.source_name_list, mus):

--- a/alea/blueice_extended_model.py
+++ b/alea/blueice_extended_model.py
@@ -1,4 +1,6 @@
 from pydoc import locate  # to lookup likelihood class
+from typing import List
+
 from alea.statistical_model import StatisticalModel
 from alea.simulators import BlueiceDataGenerator
 from alea.utils import adapt_likelihood_config_for_blueice
@@ -78,7 +80,7 @@ class BlueiceExtendedModel(StatisticalModel):
         for ll in self._likelihood.likelihood_list[:-1]:  # ancillary likelihood does not contribute
 
             ll_pars = list(ll.rate_parameters.keys()) + list(ll.shape_parameters.keys())
-            call_args = {k:i for k,i in kwargs.items() if k in ll_pars}
+            call_args = {k:i for k, i in kwargs.items() if k in ll_pars}
             if "livetime_days" in kwargs:
                 call_args["livetime_days"] = kwargs["livetime_days"]
 
@@ -114,16 +116,18 @@ class BlueiceExtendedModel(StatisticalModel):
             for p in self.parameters:
                 blueice_config[p.name] = blueice_config.get(p.name, p.nominal_value)
 
-            #add all parameters to extra_dont_hash for each source unless it is used:
-            for i,source in enumerate(config["sources"]):
-                parameters_to_ignore = [ p.name for p in self.parameters if (p.type == "shape") & (p.name not in source["parameters"])]
-                parameters_to_ignore += [ p.name for p in self.parameters if (p.type == "efficiency")] # no efficiency affects PDF
+            # add all parameters to extra_dont_hash for each source unless it is used:
+            for i, source in enumerate(config["sources"]):
+                parameters_to_ignore: List[str] = [p.name for p in self.parameters if (p.type == "shape")
+                                                   & (p.name not in source["parameters"])]
+                # no efficiency affects PDF:
+                parameters_to_ignore += [ p.name for p in self.parameters if (p.type == "efficiency")]
                 parameters_to_ignore += source.get("extra_dont_hash_settings", [])
 
-                #ignore all shape parameters known to this model not named specifically in the source:
-                blueice_config["sources"][i]["extra_dont_hash_settings"] =  parameters_to_ignore
+                # ignore all shape parameters known to this model not named specifically in the source:
+                blueice_config["sources"][i]["extra_dont_hash_settings"] = parameters_to_ignore
 
-            ll = likelihood_object(blueice_config)
+            ll = likelihood_object(blueice_config) # noqa: E127
 
             for source in config["sources"]:
 
@@ -152,16 +156,17 @@ class BlueiceExtendedModel(StatisticalModel):
                 # Set efficiency parameters
                 if source.get("apply_efficiency", False):
                     assert "efficiency_name" in source, "Unspecified efficiency_name for source {:s}".format(source["name"])
-                    efficiency_name  = source["efficiency_name"]
+                    efficiency_name = source["efficiency_name"]
                     assert efficiency_name in source["parameters"], "The efficiency_name for source {:s} is not in its parameter list".format(source["name"])
                     efficiency_parameter = self.parameters[efficiency_name]
-                    assert efficiency_parameter.type == "efficiency", "The parameter {:s} must be an efficiency".format(efficiency_name)
+                    assert efficiency_parameter.type == "efficiency", "The parameter {:s} must" \
+                                                                      " be an efficiency".format(efficiency_name)
                     limits = efficiency_parameter.fit_limits
-                    assert 0<=limits[0], "Efficiency parameters including {:s} must be constrained to be nonngative".format(efficiency_name)
-                    assert np.isfinite(limits[1]), "Efficiency parameters including {:s} must be constrained to be finite".format(efficiency_name)
-                    ll.add_shape_parameter(efficiency_name, anchors=(limits[0],limits[1]))
-
-
+                    assert 0 <= limits[0], 'Efficiency parameters including {:s} must be' \
+                                         ' constrained to be nonnegative'.format(efficiency_name)
+                    assert np.isfinite(limits[1]), 'Efficiency parameters including {:s} must be' \
+                                                   ' constrained to be finite'.format(efficiency_name)
+                    ll.add_shape_parameter(efficiency_name, anchors=(limits[0], limits[1]))
 
 
             ll.prepare()

--- a/alea/examples/unbinned_wimp_statistical_model.yaml
+++ b/alea/examples/unbinned_wimp_statistical_model.yaml
@@ -33,6 +33,18 @@ parameter_definition:
       - null
     fit_guess: 1.0
 
+  signal_efficiency:
+    nominal_value: 1.0
+    ptype: efficiency
+    uncertainty: 0.1
+    relative_uncertainty: true
+    fittable: true
+    fit_limits:
+      - 0
+      - 10.
+    fit_guess: 1.0
+    description: Parameter to account for the uncertain signal expectation given a certain cross-section
+
   # er_band_shift:
   #   nominal_value: 0
   #   ptype: shape
@@ -76,9 +88,10 @@ likelihood_config:
         parameters:
           - wimp_rate_multiplier
           - wimp_mass
+          - signal_efficiency
         template_filename: wimp50gev_template.h5
-        apply_efficiency: False
-        efficiency_name: 'signal_eff'  # TODO: Check
+        apply_efficiency: True
+        efficiency_name: signal_efficiency  # TODO: Check
 
     # SR1
     - name: sr1
@@ -104,6 +117,7 @@ likelihood_config:
         parameters:
           - wimp_rate_multiplier
           - wimp_mass
+          - signal_efficiency
         template_filename: wimp50gev_template.h5
-        apply_efficiency: False
-        efficiency_name: 'wimp_eff'  # TODO: Check
+        apply_efficiency: True
+        efficiency_name: signal_efficiency  # TODO: Check

--- a/alea/examples/unbinned_wimp_statistical_model.yaml
+++ b/alea/examples/unbinned_wimp_statistical_model.yaml
@@ -91,7 +91,7 @@ likelihood_config:
           - signal_efficiency
         template_filename: wimp50gev_template.h5
         apply_efficiency: True
-        efficiency_name: signal_efficiency  # TODO: Check
+        efficiency_name: signal_efficiency
 
     # SR1
     - name: sr1
@@ -120,4 +120,4 @@ likelihood_config:
           - signal_efficiency
         template_filename: wimp50gev_template.h5
         apply_efficiency: True
-        efficiency_name: signal_efficiency  # TODO: Check
+        efficiency_name: signal_efficiency

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -9,7 +9,7 @@ class Parameter:
         name (str): The name of the parameter.
         nominal_value (float, optional): The nominal value of the parameter.
         fittable (bool, optional): Indicates if the parameter is fittable or always fixed.
-        ptype (str, optional): The type of the parameter.
+        ptype (str, optional): The ptype of the parameter.
         uncertainty (float or str, optional):
             The uncertainty of the parameter. If a string,
             it can be evaluated as a numpy or scipy function to define non-gaussian constraints.
@@ -39,7 +39,7 @@ class Parameter:
         self.name = name
         self.nominal_value = nominal_value
         self.fittable = fittable
-        self.type = ptype
+        self.ptype = ptype
         self._uncertainty = uncertainty
         self.relative_uncertainty = relative_uncertainty
         self.blueice_anchors = blueice_anchors

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -284,9 +284,9 @@ class StatisticalModel:
                     "You must set parameter_interval_bounds in the parameter config"
                     " or when calling confidence_interval")
 
-        if parameter_of_interest.type == "rate":
+        if parameter_of_interest.ptype == "rate":
             try:
-                if parameter_of_interest.type == "rate" and poi_name.endswith("_rate_multiplier"):
+                if parameter_of_interest.ptype == "rate" and poi_name.endswith("_rate_multiplier"):
                     source_name = poi_name.replace("_rate_multiplier", "")
                 else:
                     source_name = poi_name

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -163,7 +163,8 @@ class StatisticalModel:
         kw = {'metadata': metadata} if metadata is not None else dict()
         toydata_to_file(file_name, data_list, data_name_list, **kw)
 
-    def get_expectation_values(self):
+    def get_expectation_values(self, **parameter_values):
+        mus = self._ll(full_output=True, **parameter_values)
         return NotImplementedError("get_expectation_values is optional to implement")
 
     @property

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -164,7 +164,6 @@ class StatisticalModel:
         toydata_to_file(file_name, data_list, data_name_list, **kw)
 
     def get_expectation_values(self, **parameter_values):
-        mus = self._ll(full_output=True, **parameter_values)
         return NotImplementedError("get_expectation_values is optional to implement")
 
     @property


### PR DESCRIPTION
- Adds the option to add efficiency parameters. 
- adds all shape parameters not used and all efficiency parameters to each sources extra_dont_hash_settings, thereby avoiding caching PDFs for parameter changes that do not affect the PDF. 


This code produces only 4 cached PDFs (2 WIMP 2 ER): 
```

from alea.blueice_extended_model import BlueiceExtendedModel
statistical_model = BlueiceExtendedModel.from_config(config_path)


data = statistical_model.generate_data(wimp_rate_multiplier = 10.)
data[2]["signal_efficiency"] = 0.2
statistical_model.data = data
print("set signal eff to see effect on fit, should get wimp_rate_multiplier around 50:")
print(statistical_model.fit())

for signal_efficiency in [0,0.3,1,3]:
    print(statistical_model.get_expectation_values(signal_efficiency = signal_efficiency))
```

and outputs: 

`Computing/loading models on one core: 100%|█| 2/2 [00:0
Computing/loading models on one core: 100%|█| 2/2 [00:0
INFO:root:initing simulator, binned: False
INFO:root:initing simulator, binned: False

set signal eff to see effect on fit, should get wimp_rate_multiplier around 50:
({'wimp_mass': 50.0, 'livetime_sr0': 0.2, 'livetime_sr1': 1.0, 'wimp_rate_multiplier': 45.81721355528466, 'er_rate_multiplier': 1.1432726668929618, 'signal_efficiency': 0.20000990901055393}, -3111.486710614569)
{'er': 240.0, 'wimp': 0.0}
{'er': 240.0, 'wimp': 3.6}
{'er': 240.0, 'wimp': 12.0}
{'er': 240.0, 'wimp': 36.0}
`