### PR TITLE
Check if some parameter is not set as guess when fitting

### DIFF
--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -272,6 +272,10 @@ class Parameters:
             new_val = kwargs.get(name, None)
             if (return_fittable and param.fittable) or (not return_fittable):
                 values[name] = new_val if new_val is not None else param.nominal_value
+        if any(i is None for k, i in values.items()):
+            emptypars = ", ".join([k for k, i in values.items() if i is None])
+            raise AssertionError("All parameters must be set explicitly, or have a nominal value,"
+                                 " encountered for: " + emptypars)
         return values
 
     def __getattr__(self, name: str) -> Parameter:

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -221,7 +221,8 @@ class StatisticalModel:
         defaults = self.parameters(**guesses)
         if any(i is None for k, i in defaults.items()):
             emptypars = ", ".join([k for k, i in defaults.items() if i is None])
-            raise AssertionError("All parameters must be set explicitly, or have a guess for the fit, encountered for: " + emptypars)
+            raise AssertionError("All parameters must be set explicitly, or have a guess for the fit,"
+                                 " encountered for: " + emptypars)
 
         cost = self.make_objective(minus=True, **kwargs)
 

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -219,10 +219,6 @@ class StatisticalModel:
         if not self.parameters.values_in_fit_limits(**guesses):
             raise ValueError("Initial guesses are not within fit limits")
         defaults = self.parameters(**guesses)
-        if any(i is None for k, i in defaults.items()):
-            emptypars = ", ".join([k for k, i in defaults.items() if i is None])
-            raise AssertionError("All parameters must be set explicitly, or have a guess for the fit,"
-                                 " encountered for: " + emptypars)
 
         cost = self.make_objective(minus=True, **kwargs)
 

--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -219,6 +219,9 @@ class StatisticalModel:
         if not self.parameters.values_in_fit_limits(**guesses):
             raise ValueError("Initial guesses are not within fit limits")
         defaults = self.parameters(**guesses)
+        if any(i is None for k, i in defaults.items()):
+            emptypars = ", ".join([k for k, i in defaults.items() if i is None])
+            raise AssertionError("All parameters must be set explicitly, or have a guess for the fit, encountered for: " + emptypars)
 
         cost = self.make_objective(minus=True, **kwargs)
 


### PR DESCRIPTION
See issue #43 -- if you do not set guesses manually, the error message is not easy to parse. 