### PR TITLE
Fix likelihood_names check in statistical_model.store_data to handle unnamed likelihoods

### DIFF
--- a/alea/statistical_model.py
+++ b/alea/statistical_model.py
@@ -155,9 +155,9 @@ class StatisticalModel:
         if not defined, it will be ["0", "1", ..., "n-1"]
         """
         if data_name_list is None:
-            try:
-                data_name_list = self.get_likelihood_term_names()
-            except NotImplementedError:
+            if hasattr(self, "likelihood_names"):
+                data_name_list = self.likelihood_names
+            else:
                 data_name_list = ["{:d}".format(i) for i in range(len(data_list[0]))]
 
         kw = {'metadata': metadata} if metadata is not None else dict()


### PR DESCRIPTION
Check if likelihood_names exists rather than asking for the (nonexisting) get_likelihood_term_names function. Makes store_data work without setting the data name list.

Example: 
```
from alea.examples import gaussian_model
simple_model = gaussian_model.GaussianModel()
simple_model.data = simple_model.generate_data(mu=0,sigma=2)
simple_model.store_data("simple_data",[simple_model.data])
```
failed before since the store_data function was looking for a NotImplementedError but found a NoAttributeError