### PR TITLE
Livetime scaling

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -135,7 +135,7 @@ class BlueiceExtendedModel(StatisticalModel):
         self_copy.data = self_copy.generate_data()
 
         # ancillary likelihood does not contribute
-        for ll_term, parameter_names, livetime_parameter in zip( # noqa WPS352
+        for ll_term, parameter_names, livetime_parameter in zip(  # noqa WPS352
                 self_copy._likelihood.likelihood_list[:-1],
                 self_copy._likelihood.likelihood_parameters,
                 self_copy.livetime_parameter_names):
@@ -183,10 +183,13 @@ class BlueiceExtendedModel(StatisticalModel):
                     p.name for p in self.parameters if (
                         p.ptype == "shape") and (p.name not in source["parameters"])]
                 # no efficiency affects PDF:
-                parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
+                parameters_to_ignore += [
+                    p.name for p in self.parameters if (
+                        p.ptype == "efficiency")]
                 parameters_to_ignore += source.get("extra_dont_hash_settings", [])
 
-                # ignore all shape parameters known to this model not named specifically in the source:
+                # ignore all shape parameters known to this model not named specifically
+                # in the source:
                 blueice_config["sources"][i]["extra_dont_hash_settings"] = parameters_to_ignore
 
             ll = likelihood_object(blueice_config)
@@ -248,7 +251,7 @@ class BlueiceExtendedModel(StatisticalModel):
 
     def _ll(self, **generate_values) -> float:
         livetime_days = [generate_values.get(ln, None) for ln in self.livetime_parameter_names]
-        return self._likelihood(livetime_days = livetime_days, **generate_values)
+        return self._likelihood(livetime_days=livetime_days, **generate_values)
 
     def _generate_data(self, **generate_values) -> dict:
         """
@@ -279,11 +282,11 @@ class BlueiceExtendedModel(StatisticalModel):
             data_name_list = self.likelihood_names + ["generate_values"]
         super().store_data(file_name, data_list, data_name_list, metadata)
 
-    def _generate_science_data(self, **generate_values) -> dict:
+    def _generate_science_data(self,**generate_values)-> dict:
         """Generate the science data for all likelihood terms except the ancillary likelihood."""
-        livetime_days = [generate_values.get(ln,None) for ln in self.livetime_parameter_names]
-        science_data = [
-            gen.simulate(livetime_days = lt, **generate_values) for gen, lt in zip(self.data_generators, livetime_days)]
+        livetime_days = [generate_values.get(ln, None) for ln in self.livetime_parameter_names]
+        science_data = [gen.simulate(livetime_days=lt, **generate_values)
+                        for gen, lt in zip(self.data_generators, livetime_days)]
         return dict(zip(self.likelihood_names[:-1], science_data))
 
     def _generate_ancillary_measurements(self, **generate_values) -> dict:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -279,8 +279,10 @@ class BlueiceExtendedModel(StatisticalModel):
 
     def _generate_science_data(self, **generate_values) -> dict:
         """Generate the science data for all likelihood terms except the ancillary likelihood."""
+        livetime_days = [generate_values.get(ln,None) for ln in self.livetime_parameter_names]
+        print(livetime_days)
         science_data = [
-            gen.simulate(**generate_values) for gen in self.data_generators]
+            gen.simulate(livetime_days = lt, **generate_values) for gen, lt in zip(self.data_generators, livetime_days)]
         return dict(zip(self.likelihood_names[:-1], science_data))
 
     def _generate_ancillary_measurements(self, **generate_values) -> dict:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -280,7 +280,6 @@ class BlueiceExtendedModel(StatisticalModel):
     def _generate_science_data(self, **generate_values) -> dict:
         """Generate the science data for all likelihood terms except the ancillary likelihood."""
         livetime_days = [generate_values.get(ln,None) for ln in self.livetime_parameter_names]
-        print(livetime_days)
         science_data = [
             gen.simulate(livetime_days = lt, **generate_values) for gen, lt in zip(self.data_generators, livetime_days)]
         return dict(zip(self.likelihood_names[:-1], science_data))

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -135,7 +135,7 @@ class BlueiceExtendedModel(StatisticalModel):
         self_copy.data = self_copy.generate_data()
 
         # ancillary likelihood does not contribute
-        for ll_term, parameter_names, livetime_parameter in zip(
+        for ll_term, parameter_names, livetime_parameter in zip( # noqa WPS352
                 self_copy._likelihood.likelihood_list[:-1],
                 self_copy._likelihood.likelihood_parameters,
                 self_copy.livetime_parameter_names):

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -50,10 +50,10 @@ class BlueiceExtendedModel(StatisticalModel):
         super().__init__(parameter_definition=parameter_definition, **kwargs)
         self._likelihood = self._build_ll_from_config(likelihood_config)
         self.likelihood_names = [t["name"] for t in likelihood_config["likelihood_terms"]]
+        self.likelihood_names.append("ancillary_likelihood")
         self.livetime_parameter_names = [t.get("livetime_parameter", None) for t in
                                          likelihood_config["likelihood_terms"]]
         self.livetime_parameter_names += [None]  # ancillary likelihood
-        self.likelihood_names.append("ancillary_likelihood")
         self.data_generators = self._build_data_generators()
 
     @classmethod

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -27,7 +27,8 @@ class BlueiceExtendedModel(StatisticalModel):
         is_data_set (bool): Whether data is set.
         _likelihood (LogLikelihoodSum): A blueice LogLikelihoodSum instance.
         likelihood_names (list): List of likelihood names.
-        livetime_parameter_names (list): List of the name of the livetime of each term, None if not specified
+        livetime_parameter_names (list): List of the name of the livetime of each term,
+            None if not specified
         data_generators (list): List of data generators for each likelihood term.
 
     Args:
@@ -49,8 +50,9 @@ class BlueiceExtendedModel(StatisticalModel):
         super().__init__(parameter_definition=parameter_definition, **kwargs)
         self._likelihood = self._build_ll_from_config(likelihood_config)
         self.likelihood_names = [t["name"] for t in likelihood_config["likelihood_terms"]]
-        self.livetime_parameter_names = [t.get("livetime_parameter", None) for t in likelihood_config["likelihood_terms"]]
-        self.livetime_parameter_names += [None] # ancillary likelihood
+        self.livetime_parameter_names = [t.get("livetime_parameter", None) for t in
+                                         likelihood_config["likelihood_terms"]]
+        self.livetime_parameter_names += [None]  # ancillary likelihood
         self.likelihood_names.append("ancillary_likelihood")
         self.data_generators = self._build_data_generators()
 
@@ -245,7 +247,7 @@ class BlueiceExtendedModel(StatisticalModel):
             BlueiceDataGenerator(ll_term) for ll_term in self._likelihood.likelihood_list[:-1]]
 
     def _ll(self, **generate_values) -> float:
-        livetime_days = [generate_values.get(ln,None) for ln in self.livetime_parameter_names]
+        livetime_days = [generate_values.get(ln, None) for ln in self.livetime_parameter_names]
         return self._likelihood(livetime_days = livetime_days, **generate_values)
 
     def _generate_data(self, **generate_values) -> dict:

--- a/alea/simulators.py
+++ b/alea/simulators.py
@@ -106,11 +106,12 @@ class BlueiceDataGenerator:
             The dtype follows self.dtype.
         """
         if filter_kwargs:
-            kwargs = {k: v for k, v in kwargs.items() if k in self.parameters}
+            kwargs = {k: v for k, v in kwargs.items() if k in self.parameters + ["livetime_days"]}
 
         unmatched_item = set(self.last_kwargs.items()) ^ set(kwargs.items())
         logging.debug("filtered kwargs in simulate: " + str(kwargs))
         logging.debug("unmatched_item in simulate: " + str(unmatched_item))
+        # check if the cached generator may be used:
         if ("FAKE_PARAMETER"
                 in self.last_kwargs.keys()) or (len(unmatched_item) != 0):
             ret = self.ll(full_output=True, **kwargs)  # result, mus, ps

--- a/alea/template_source.py
+++ b/alea/template_source.py
@@ -35,7 +35,7 @@ class TemplateSource(blueice.HistogramPdfSource):
         histname = self.config['histname'].format(**format_dict)
 
         slice_args = self.config.get("slice_args", {})
-        if type(slice_args) is dict:
+        if isinstance(slice_args, dict):
             slice_args = [slice_args]
 
         h = template_to_multihist(templatename, histname)
@@ -57,7 +57,8 @@ class TemplateSource(blueice.HistogramPdfSource):
                 slice_axis_limits = sa.get(
                     "slice_axis_limits", [bes[0], bes[-1]])
                 if sum_axis:
-                    logging.debug(f"Slice and sum over axis {slice_axis} from {slice_axis_limits[0]} to {slice_axis_limits[1]}")
+                    logging.debug(
+                        f"Slice and sum over axis {slice_axis} from {slice_axis_limits[0]} to {slice_axis_limits[1]}")
                     axis_names = h.axis_names_without(slice_axis)
                     h = h.slicesum(
                         axis=slice_axis,
@@ -66,7 +67,8 @@ class TemplateSource(blueice.HistogramPdfSource):
                     h.axis_names = axis_names
                 else:
                     logging.debug(f"Normalization before slicing: {h.n}.")
-                    logging.debug(f"Slice over axis {slice_axis} from {slice_axis_limits[0]} to {slice_axis_limits[1]}")
+                    logging.debug(
+                        f"Slice over axis {slice_axis} from {slice_axis_limits[0]} to {slice_axis_limits[1]}")
                     h = h.slice(axis=slice_axis,
                                 start=slice_axis_limits[0],
                                 stop=slice_axis_limits[1])
@@ -126,7 +128,8 @@ class TemplateSource(blueice.HistogramPdfSource):
         self._n_events_histogram = h.similar_blank_histogram()
 
         h *= self.config.get('histogram_scale_factor', 1)
-        logging.debug(f"Multiplying histogram with histogram_scale_factor {self.config.get('histogram_scale_factor', 1)}. Histogram is now normalised to {h.n}.")
+        logging.debug(
+            f"Multiplying histogram with histogram_scale_factor {self.config.get('histogram_scale_factor', 1)}. Histogram is now normalised to {h.n}.")
 
         # Convert h to density...
         if self.config.get('in_events_per_bin'):
@@ -147,7 +150,7 @@ class TemplateSource(blueice.HistogramPdfSource):
         if np.min(self._pdf_histogram.histogram) < 0:
             raise AssertionError(
                 f"There are bins for source {templatename} with negative entries."
-                    )
+            )
 
     def simulate(self, n_events):
         dtype = []
@@ -189,9 +192,9 @@ class CombinedSource(blueice.HistogramPdfSource):
         templatenames = self.config['templatenames']
 
         slice_args = self.config.get("slice_args", {})
-        if type(slice_args) is dict:
+        if isinstance(slice_args, dict):
             slice_args = [slice_args]
-        if type(slice_args[0]) is dict:
+        if isinstance(slice_args[0], dict):
             slice_argss = []
             for n in histnames:
                 slice_argss.append(slice_args)
@@ -387,11 +390,11 @@ class SpectrumTemplateSource(blueice.HistogramPdfSource):
         histname = self.config['histname'].format(**format_dict)
 
         spectrum = self.config["spectrum"]
-        if type(spectrum) is str:
+        if isinstance(spectrum, str):
             spectrum = self._get_json_spectrum(spectrum.format(**format_dict))
 
         slice_args = self.config.get("slice_args", {})
-        if type(slice_args) is dict:
+        if isinstance(slice_args, dict):
             slice_args = [slice_args]
 
         h = template_to_multihist(templatename, histname)

--- a/docs/source/notebooks/placeholder.ipynb
+++ b/docs/source/notebooks/placeholder.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/placeholder.ipynb


### PR DESCRIPTION
This aims to allow runtime changing of livetime in data generation, get_expectation and likelihood evaluation. 

To test implementation: 


```
from alea.models.blueice_extended_model import BlueiceExtendedModel

model = BlueiceExtendedModel.from_config("/Users/kdund/Software/xenon_software/alea/alea/examples/configs/unbinned_wimp_statistical_model.yaml")

data = model.generate_data(er_rate_multiplier=1, wimp_rate_multiplier=1)
model.data = data

#get expectation value check: 
print(model.get_expectation_values(livetime_sr0=100, livetime_sr1=0))
print(model.get_expectation_values(livetime_sr0=1, livetime_sr1=0))
#1st is 100 times second

#likelihood evaluation check: 
ll_ratio = model.ll(livetime_sr0=1, er_rate_multiplier=1, wimp_rate_multiplier=0, livetime_sr1 = 0) / model.ll(livetime_sr0=10, er_rate_multiplier=0.1, wimp_rate_multiplier=0, livetime_sr1 = 0) #check if livetime/rate is degenerate as expected. 
print(ll_ratio, "approx equal 1")

#data generation check: 
print(len(model.generate_data(er_rate_multiplier=1, wimp_rate_multiplier=1, livetime_sr0=10)['sr0'])) #around 
 
```