### PR TITLE
Add optional argument `degree_of_freedom` for `asymptotic_critical_value`

### DIFF
--- a/alea/examples/configs/unbinned_wimp_running.yaml
+++ b/alea/examples/configs/unbinned_wimp_running.yaml
@@ -49,6 +49,7 @@ computation_options:
         n_batch: 40,
         compute_confidence_interval: True,
         limit_threshold: "thresholds.json",
+        asymptotic_dof: 1,
         toydata_mode: "generate_and_store",
         toydata_filename: "toyfile_wimp_mass_{wimp_mass:d}_poi_expectation_{poi_expectation:.2f}.h5",
       }

--- a/alea/model.py
+++ b/alea/model.py
@@ -72,6 +72,7 @@ class StatisticalModel:
         confidence_level: float = 0.9,
         confidence_interval_kind: str = "central",  # one of central, upper, lower
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
+        asymptotic_dof: Optional[int] = None,
         data: Optional[Union[dict, list]] = None,
         **kwargs,
     ):
@@ -93,6 +94,7 @@ class StatisticalModel:
             raise ValueError("confidence_interval_kind must be one of central, upper, lower")
         self._confidence_interval_kind = confidence_interval_kind
         self.confidence_interval_threshold = confidence_interval_threshold
+        self.asymptotic_dof = asymptotic_dof
         self._define_parameters(parameter_definition)
 
         self._check_ll_and_generate_data_signature()
@@ -355,6 +357,7 @@ class StatisticalModel:
         confidence_level: Optional[float] = None,
         confidence_interval_kind: Optional[str] = None,
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
+        asymptotic_dof: Optional[int] = None,
         **kwargs,
     ) -> Tuple[str, Callable[[float], float], Tuple[float, float]]:
         """Helper function for confidence_interval that does the input checks and return bounds.
@@ -400,8 +403,20 @@ class StatisticalModel:
                 confidence_interval_threshold = self.confidence_interval_threshold
             else:
                 # use asymptotic thresholds assuming the test statistic is Chi2 distributed
+                if asymptotic_dof is None:
+                    if self.asymptotic_dof is not None:
+                        degree_of_freedom = self.asymptotic_dof
+                    else:
+                        degree_of_freedom = 1
+                else:
+                    if self.asymptotic_dof is not None:
+                        raise ValueError(
+                            "You cannot set asymptotic_dof twice, "
+                            "once in the constructor and once in the method call"
+                        )
+                    degree_of_freedom = asymptotic_dof
                 critical_value = asymptotic_critical_value(
-                    confidence_interval_kind, confidence_level
+                    confidence_interval_kind, confidence_level, degree_of_freedom
                 )
 
                 def confidence_interval_threshold(_):
@@ -427,6 +442,7 @@ class StatisticalModel:
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
         confidence_interval_args: Optional[dict] = None,
         best_fit_args: Optional[dict] = None,
+        asymptotic_dof: Optional[int] = None,
     ) -> Tuple[float, float]:
         """Uses self.fit to compute confidence intervals for a certain named parameter. If the
         parameter is a rate parameter, and the model has expectation values implemented, the bounds
@@ -454,6 +470,7 @@ class StatisticalModel:
                 profile likelihood-- mainly used for 1-D slices of higher-dimensional confidence
                 volumes, where the global best-fit may not be along the profile.
                 If None, will be set to confidence_interval_args.
+            asymptotic_dof (int, optional (default=None)): Degrees of freedom for asymptotic
 
         """
         if confidence_interval_args is None:
@@ -466,6 +483,7 @@ class StatisticalModel:
             confidence_level,
             confidence_interval_kind,
             confidence_interval_threshold,
+            asymptotic_dof,
             **confidence_interval_args,
         )
         (

--- a/alea/model.py
+++ b/alea/model.py
@@ -357,7 +357,7 @@ class StatisticalModel:
         confidence_level: Optional[float] = None,
         confidence_interval_kind: Optional[str] = None,
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
-        asymptotic_dof: Optional[int] = 1,
+        asymptotic_dof: Optional[int] = None,
         **kwargs,
     ) -> Tuple[str, Callable[[float], float], Tuple[float, float]]:
         """Helper function for confidence_interval that does the input checks and return bounds.
@@ -403,7 +403,12 @@ class StatisticalModel:
                 confidence_interval_threshold = self.confidence_interval_threshold
             else:
                 # use asymptotic thresholds assuming the test statistic is Chi2 distributed
-                if asymptotic_dof is not None:
+                if asymptotic_dof is None:
+                    if self.asymptotic_dof is not None:
+                        degree_of_freedom = self.asymptotic_dof
+                    else:
+                        degree_of_freedom = 1
+                else:
                     if self.asymptotic_dof is not None:
                         if asymptotic_dof != self.asymptotic_dof:
                             warnings.warn(
@@ -412,11 +417,6 @@ class StatisticalModel:
                                 f"{self.asymptotic_dof}. Be careful!"
                             )
                     degree_of_freedom = asymptotic_dof
-                else:
-                    if self.asymptotic_dof is not None:
-                        degree_of_freedom = self.asymptotic_dof
-                    else:
-                        degree_of_freedom = 1
                 critical_value = asymptotic_critical_value(
                     confidence_interval_kind, confidence_level, degree_of_freedom
                 )
@@ -444,7 +444,7 @@ class StatisticalModel:
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
         confidence_interval_args: Optional[dict] = None,
         best_fit_args: Optional[dict] = None,
-        asymptotic_dof: Optional[int] = 1,
+        asymptotic_dof: Optional[int] = None,
     ) -> Tuple[float, float]:
         """Uses self.fit to compute confidence intervals for a certain named parameter. If the
         parameter is a rate parameter, and the model has expectation values implemented, the bounds

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -91,7 +91,7 @@ class BlueiceExtendedModel(StatisticalModel):
                 If data is a list, it must be a list of length len(self.likelihood_names) + 1.
 
         Raises:
-            ValueError: If data is not a list of length len(self.likelihood_names) + 1.
+            Warning: If data is not a list of length len(self.likelihood_names) + 1.
 
         Caution:
             The self._data is read-only, so you can not change the data after it is set.

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -156,6 +156,7 @@ class Runner:
             confidence_interval_kind,
             confidence_level,
             statistical_model_args.get("limit_threshold_interpolation", False),
+            statistical_model_args.get("asymptotic_dof", None),
         )
 
     @property

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -156,7 +156,7 @@ class Runner:
             confidence_interval_kind,
             confidence_level,
             statistical_model_args.get("limit_threshold_interpolation", False),
-            statistical_model_args.get("asymptotic_dof", None),
+            statistical_model_args.get("asymptotic_dof", 1),
         )
 
     @property

--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -453,6 +453,10 @@ class Submitter:
             runner_args["statistical_model_args"][
                 "limit_threshold_interpolation"
             ] = runner_args.pop("limit_threshold_interpolation")
+        if "asymptotic_dof" in runner_args:
+            runner_args["statistical_model_args"]["asymptotic_dof"] = runner_args.pop(
+                "asymptotic_dof"
+            )
 
     @staticmethod
     def check_redunant_arguments(runner_args, allowed_special_args: List[str] = []):

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -349,7 +349,7 @@ class NeymanConstructor(SubmitterLocal):
         confidence_interval_kind,
         confidence_level,
         limit_threshold_interpolation,
-        asymptotic_dof: Optional[int] = None,
+        asymptotic_dof: Optional[int] = 1,
     ):
         """Get confidence interval threshold function from limit_threshold file. If the
         limit_threshold file does not contain the threshold, it will interpolate the threshold from
@@ -365,7 +365,7 @@ class NeymanConstructor(SubmitterLocal):
             confidence_level (float): confidence level
             limit_threshold_interpolation (bool): whether to interpolate the threshold from the
                 existing threshold, if the limit_threshold file does not contain the threshold
-            asymptotic_dof (int, optional (default=None)):
+            asymptotic_dof (int, optional (default=1)):
                 degrees of freedom for asymptotic critical value
 
         """

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -7,7 +7,7 @@ import itertools
 import operator
 from functools import reduce
 from copy import deepcopy
-from typing import List, Dict, Any, cast
+from typing import List, Dict, Any, Optional, Callable, cast
 
 import numpy as np
 from scipy.interpolate import interp1d, RegularGridInterpolator
@@ -349,6 +349,7 @@ class NeymanConstructor(SubmitterLocal):
         confidence_interval_kind,
         confidence_level,
         limit_threshold_interpolation,
+        asymptotic_dof: Optional[int] = None,
     ):
         """Get confidence interval threshold function from limit_threshold file. If the
         limit_threshold file does not contain the threshold, it will interpolate the threshold from
@@ -364,6 +365,8 @@ class NeymanConstructor(SubmitterLocal):
             confidence_level (float): confidence level
             limit_threshold_interpolation (bool): whether to interpolate the threshold from the
                 existing threshold, if the limit_threshold file does not contain the threshold
+            asymptotic_dof (int, optional (default=None)):
+                degrees of freedom for asymptotic critical value
 
         """
 
@@ -372,7 +375,7 @@ class NeymanConstructor(SubmitterLocal):
 
         threshold = load_json(limit_threshold)
 
-        func_list = []
+        func_list: List[Optional[Callable]] = []
         for i_hypo in range(len(hypotheses_values)):
             hypothesis = hypotheses_values[i_hypo]
 
@@ -454,7 +457,9 @@ class NeymanConstructor(SubmitterLocal):
                 poi_values,
                 threshold_values,
                 bounds_error=False,
-                fill_value=asymptotic_critical_value(confidence_interval_kind, confidence_level),
+                fill_value=asymptotic_critical_value(
+                    confidence_interval_kind, confidence_level, asymptotic_dof
+                ),
             )
             func_list.append(func)
 

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -297,6 +297,11 @@ def asymptotic_critical_value(
     Returns:
         float: critical value
 
+    Raises:
+        ValueError: if confidence_interval_kind is not 'lower', 'upper' or 'central'
+        ValueError: if degree_of_freedom is not None and not 1, when confidence_interval_kind is
+            'lower' or 'upper'
+
     """
     if confidence_interval_kind in {"lower", "upper"}:
         if (degree_of_freedom is not None) and (degree_of_freedom != 1):

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -283,25 +283,32 @@ def get_template_folder_list(likelihood_config, extra_template_path: Optional[st
     return template_folder_list
 
 
-def asymptotic_critical_value(confidence_interval_kind: str, confidence_level: float):
+def asymptotic_critical_value(
+    confidence_interval_kind: str, confidence_level: float, degree_of_freedom: Optional[int] = None
+):
     """Return the critical value for the confidence interval.
 
     Args:
         confidence_interval_kind (str): confidence interval kind, either 'lower', 'upper' or
             'central'
         confidence_level (float): confidence level
+        degree_of_freedom (int, optional (default=None)): degree of freedom
 
     Returns:
         float: critical value
 
-    Caution:
-        The critical value is calculated from chi2 distribution with 1 degree of freedom.
-
     """
     if confidence_interval_kind in {"lower", "upper"}:
+        if (degree_of_freedom is not None) and (degree_of_freedom != 1):
+            raise ValueError(
+                f"degree_of_freedom must be 1 for {confidence_interval_kind} confidence interval"
+            )
         critical_value = chi2(1).isf(2 * (1.0 - confidence_level))
     elif confidence_interval_kind == "central":
-        critical_value = chi2(1).isf(1.0 - confidence_level)
+        if degree_of_freedom is None:
+            critical_value = chi2(1).isf(1.0 - confidence_level)
+        else:
+            critical_value = chi2(degree_of_freedom).isf(1.0 - confidence_level)
     else:
         raise ValueError(
             f"confidence_interval_kind must be either 'lower', 'upper' or 'central', "

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,7 +9,7 @@ from inference_interface import toyfiles_to_numpy
 from alea.utils import load_yaml
 from alea.runner import Runner
 
-from .test_gaussian_model import gaussian_model_parameter_definition
+from test_gaussian_model import gaussian_model_parameter_definition
 
 
 COMPUTE_CONFIDENCE_INTERVAL = True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,7 +9,7 @@ from inference_interface import toyfiles_to_numpy
 from alea.utils import load_yaml
 from alea.runner import Runner
 
-from test_gaussian_model import gaussian_model_parameter_definition
+from .test_gaussian_model import gaussian_model_parameter_definition
 
 
 COMPUTE_CONFIDENCE_INTERVAL = True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,13 @@ class TestUtils(TestCase):
             asymptotic_critical_value("invalid", confidence_level)
         with self.assertRaises(ValueError):
             asymptotic_critical_value("lower", confidence_level, 2)
+        critical_value_central = chi2(2).isf((1.0 - confidence_level))
+        self.assertEqual(
+            asymptotic_critical_value("central", confidence_level, 2), critical_value_central
+        )
+        self.assertEqual(
+            asymptotic_critical_value("central", confidence_level, 2), critical_value_central
+        )
 
     def test_within_limits(self):
         """Test of the within_limits function."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,10 +44,8 @@ class TestUtils(TestCase):
             asymptotic_critical_value("invalid", confidence_level)
         with self.assertRaises(ValueError):
             asymptotic_critical_value("lower", confidence_level, 2)
+
         critical_value_central = chi2(2).isf((1.0 - confidence_level))
-        self.assertEqual(
-            asymptotic_critical_value("central", confidence_level, 2), critical_value_central
-        )
         self.assertEqual(
             asymptotic_critical_value("central", confidence_level, 2), critical_value_central
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,10 @@ class TestUtils(TestCase):
         critical_value = chi2(1).isf(2 * (1.0 - confidence_level))
         self.assertEqual(asymptotic_critical_value("lower", confidence_level), critical_value)
         self.assertEqual(asymptotic_critical_value("upper", confidence_level), critical_value)
+        with self.assertRaises(ValueError):
+            asymptotic_critical_value("invalid", confidence_level)
+        with self.assertRaises(ValueError):
+            asymptotic_critical_value("lower", confidence_level, 2)
 
     def test_within_limits(self):
         """Test of the within_limits function."""


### PR DESCRIPTION
Resolve: https://github.com/XENONnT/alea/issues/83

## What does the code in this PR do / what does it improve?

Add optional argument `degree_of_freedom` for `asymptotic_critical_value`

## Can you briefly describe how it works?

1. For models, if `asymptotic_dof` is provided as an `__init__` argument, the `StatisticalModel.asymptotic_dof` will be used in `_confidence_interval_checks`.
2. For runners, if `asymptotic_dof` is in `statistical_model_args`, the `Runner.confidence_interval_thresholds` will be set according to `asymptotic_dof`, and further used in CL calculation.

## Can you give a minimal working example (or illustrate with a figure)?

```
from alea.utils import asymptotic_critical_value
asymptotic_critical_value("central", 0.9)
>>> 2.705543454095414
```

## What are the potential drawbacks of the codes?

When `"confidence_interval_kind"` is not `"lower"` or `"upper"`, and `degree_of_freedom` is not `None` or 1, `asymptotic_critical_value` will raise an error.

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the open issues on github?_
