### PR TITLE
Add column to toyMC results with minuit convergence flag

### DIFF
--- a/alea/runner.py
+++ b/alea/runner.py
@@ -254,10 +254,9 @@ class Runner:
     def _get_parameter_list(self):
         """Get parameter list and result list from statistical model."""
         parameter_list = sorted(self.model.get_parameter_list())
-        # add likelihood, lower limit, and upper limit
-        result_names = parameter_list + ["ll", "dl", "ul"]
-        result_dtype = [(n, float) for n in parameter_list]
-        result_dtype += [(n, float) for n in ["ll", "dl", "ul"]]
+        # add likelihood, lower limit, upper limit, and the migrad valid fit bool
+        result_names = parameter_list + ["ll", "dl", "ul", "valid_fit"]
+        result_dtype = [(n, float) for n in result_names]
         return result_names, result_dtype
 
     def _get_hypotheses(self):
@@ -434,6 +433,7 @@ class Runner:
             for i_hypo, hypothesis_values in enumerate(self._hypotheses_values):
                 fit_result, max_llh = self.model.fit(**hypothesis_values)
                 fit_result["ll"] = max_llh
+                fit_result["valid_fit"] = self.model.minuit_object.valid
 
                 if self._compute_confidence_interval and (self.poi not in hypothesis_values):
                     # hypothesis_values should only be a fittable subset of parameters


### PR DESCRIPTION
This PR adds the minuit convergence flag to the results. 
Closes #90 

Example to check: 

```
from alea.utils import load_yaml
from alea.runner import Runner
import numpy as np

runners = dict()
for fittable_sigma in [False, True]:
    runner = Runner(
        statistical_model = "alea.examples.gaussian_model.GaussianModel",
        poi = "mu",
        hypotheses = ["free","zero","true"],
        n_mc = 100,
        nominal_values = {"sigma":1.0},
        generate_values = {"mu":1.0},
        parameter_definition= {
        "mu": {
            "fit_guess": 0.0,
            "fittable": True,
            "nominal_value": 0.0,
            "parameter_interval_bounds": [
                -10,
                10,
            ],
        },
        "sigma": {
            "fittable": fittable_sigma,
            "nominal_value": 1.0,
            "fit_limits": [0,np.inf],
        },
    },
    output_filename = "test_sigmafree_{:d}.hdf".format(int(fittable_sigma))
    )
    runner.run()
    
    

for sigma_free in [False, True]:
    run_results = ii.toyfiles_to_numpy("test_sigmafree_{:d}.hdf".format(int(sigma_free)))
    print([np.mean(run_results[k]["valid_fit"]) for k in ["free","zero","true"]]) #the second, only 0.25 of fits converge or so
```