### PR TITLE
Allow submitter to skip the already succeeded files

### DIFF
--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -71,6 +71,7 @@ class Submitter:
         computation: str = "discovery_power",
         outputfolder: Optional[str] = None,
         debug: bool = False,
+        resubmit: bool = False,
         loglevel: str = "INFO",
         **kwargs,
     ):
@@ -98,6 +99,7 @@ class Submitter:
 
         self.computation_dict = computation_options[computation]
         self.debug = debug
+        self.resubmit = resubmit
 
         # Find statistical model config file
         if not os.path.exists(self.statistical_model_config):
@@ -355,7 +357,15 @@ class Submitter:
                     + " ".join(map(shlex.quote, script.split(" ")))
                 )
 
-                yield script, i_args["output_filename"]
+                output_filename = i_args["output_filename"]
+                if (
+                    (output_filename is not None)
+                    and os.path.exists(output_filename)
+                    and self.resubmit
+                ):
+                    continue
+                else:
+                    yield script, output_filename
 
     @staticmethod
     def update_n_batch(runner_args):

--- a/bin/alea-submission
+++ b/bin/alea-submission
@@ -37,6 +37,11 @@ def main():
         default=None,
         help="Overwriting the outputfolder, usually defined in runner config file",
     )
+    parser.add_argument(
+        "--resubmit",
+        action="store_true",
+        help="Resubmit when the output file does not exist",
+    )
     parsed_args = parser.parse_args()
 
     if parsed_args.computation == "threshold":
@@ -66,6 +71,7 @@ def main():
     kwargs = {
         "computation": parsed_args.computation,
         "debug": parsed_args.debug,
+        "resubmit": parsed_args.resubmit,
     }
     # if outputfolder is provided, overwrite the one in runner config file
     if parsed_args.outputfolder:


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

```
$HOME/alea/bin/alea-submission $HOME/alea/alea/examples/configs/unbinned_wimp_running.yaml --slurm --computation discovery_power --outputfolder $HOME/out_alea --resubmit
```

will ONLY submit the jobs whose `output_filename` doe not yet exist.

## Can you briefly describe how it works?

Added an if statement in `Submitter.computation_tickets_generator`. When the attribute `Submitter.resubmit` is `True`, the jobs already finished will be skipped.

## Can you give a minimal working example (or illustrate with a figure)?

## What are the potential drawbacks of the codes?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
