### PR TITLE
Update Neyman threshold when changing runner_args

### DIFF
--- a/alea/model.py
+++ b/alea/model.py
@@ -95,16 +95,19 @@ class StatisticalModel:
         self._confidence_interval_kind = confidence_interval_kind
         self.confidence_interval_threshold = confidence_interval_threshold
         self.asymptotic_dof = asymptotic_dof
-        self._define_parameters(parameter_definition)
+        nominal_values = kwargs.get("nominal_values", {})
+        self._define_parameters(parameter_definition, nominal_values)
 
         self._check_ll_and_generate_data_signature()
-        self.set_nominal_values(**kwargs.get("nominal_values", {}))
 
-    def _define_parameters(self, parameter_definition):
+    def _define_parameters(self, parameter_definition, nominal_values=None):
         """Initialize the parameters of the model."""
         if parameter_definition is None:
             self.parameters = Parameters()
         elif isinstance(parameter_definition, dict):
+            for name, definition in parameter_definition.items():
+                if name in nominal_values:
+                    definition["nominal_value"] = nominal_values[name]
             self.parameters = Parameters.from_config(parameter_definition)
         elif isinstance(parameter_definition, list):
             self.parameters = Parameters.from_list(parameter_definition)

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -24,6 +24,8 @@ class Parameter:
             for any value in between.
         fit_limits (Tuple[float, float], optional (default=None)):
             The limits for fitting the parameter.
+        static (bool, optional (default=False)):
+            If True, the parameter is static and cannot be changed from its nominal value.
         parameter_interval_bounds (Tuple[float, float], optional (default=None)):
             Limits for computing confidence intervals.
         fit_guess (float, optional (default=None)): The initial guess for fitting the parameter.
@@ -41,6 +43,7 @@ class Parameter:
         relative_uncertainty: Optional[bool] = None,
         blueice_anchors: Optional[List] = None,
         fit_limits: Optional[Tuple] = None,
+        static: Optional[bool] = False,
         parameter_interval_bounds: Optional[Tuple[float, float]] = None,
         fit_guess: Optional[float] = None,
         description: Optional[str] = None,
@@ -54,6 +57,7 @@ class Parameter:
         self.uncertainty = uncertainty
         self.blueice_anchors = blueice_anchors
         self.fit_limits = fit_limits
+        self.static = static
         self.parameter_interval_bounds = parameter_interval_bounds
         self.fit_guess = fit_guess
         self.description = description
@@ -120,14 +124,6 @@ class Parameter:
     @parameter_interval_bounds.setter
     def parameter_interval_bounds(self, value: Optional[Tuple[float, float]]) -> None:
         self._parameter_interval_bounds = value
-
-    @property
-    def static(self) -> bool:
-        """Return True if the parameter is static."""
-        static = ~self.fittable
-        static &= self.ptype not in ["livetime", "rate"]
-        static &= self.blueice_anchors is None
-        return bool(static)
 
     @property
     def nominal_value(self) -> Optional[float]:

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -382,7 +382,7 @@ class Parameters:
 
         for name, param in self.parameters.items():
             new_val = kwargs.get(name, None)
-            if param.static and (new_val != param.nominal_value):
+            if param.static and (new_val != param.nominal_value) and (new_val is not None):
                 raise ValueError(f"Parameter {name} is static. You can't change its value from its nominal value (tried to override nominal value {param.nominal_value} with {new_val}).)")
             if (return_fittable and param.fittable) or (not return_fittable):
                 values[name] = new_val if new_val is not None else param.nominal_value

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -134,7 +134,9 @@ class Parameter:
     def nominal_value(self, value: Optional[float]) -> None:
         if self.static and (value != self._nominal_value):
             raise ValueError(
-                f"{self.name} is a static parameter. You can't change its nominal value (tried to override nominal value {self._nominal_value} with {value})."
+                f"{self.name} is a static parameter. "
+                "You can't change its nominal value "
+                f"(tried to override nominal value {self._nominal_value} with {value})."
             )
         self._nominal_value = value
 
@@ -382,7 +384,10 @@ class Parameters:
             new_val = kwargs.get(name, None)
             if param.static and (new_val != param.nominal_value) and (new_val is not None):
                 raise ValueError(
-                    f"Parameter {name} is static. You can't change its value from its nominal value (tried to override nominal value {param.nominal_value} with {new_val}).)"
+                    f"Parameter {name} is static. "
+                    "You can't change its value from its nominal value "
+                    f"(tried to override nominal value {param.nominal_value} "
+                    f"with {new_val}).)"
                 )
             if (return_fittable and param.fittable) or (not return_fittable):
                 values[name] = new_val if new_val is not None else param.nominal_value

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -33,6 +33,8 @@ class Parameter:
 
     """
 
+    _uncertainty: Optional[Union[float, str]]
+
     def __init__(
         self,
         name: str,

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -136,8 +136,8 @@ class Parameter:
 
     @nominal_value.setter
     def nominal_value(self, value: Optional[float]) -> None:
-        if self.static:
-            raise ValueError(f"{self.name} is a static parameter. You can't change its nominal value.")
+        if self.static and (value != self._nominal_value):
+            raise ValueError(f"{self.name} is a static parameter. You can't change its nominal value (tried to override nominal value {self._nominal_value} with {value}).")
         self._nominal_value = value
 
     def __eq__(self, other: object) -> bool:
@@ -383,7 +383,7 @@ class Parameters:
         for name, param in self.parameters.items():
             new_val = kwargs.get(name, None)
             if param.static and (new_val != param.nominal_value):
-                raise ValueError(f"Parameter {name} is static. You can't change its value from its nominal value.")
+                raise ValueError(f"Parameter {name} is static. You can't change its value from its nominal value (tried to override nominal value {param.nominal_value} with {new_val}).)")
             if (return_fittable and param.fittable) or (not return_fittable):
                 values[name] = new_val if new_val is not None else param.nominal_value
         if any(i is None for k, i in values.items()):

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -177,7 +177,8 @@ class NeymanConstructor(SubmitterLocal):
                     f"The lowest log likelihood ratio is negative {llrs.min():.2e}, "
                     f"total fraction of negative log likelihood ratio is "
                     f"{(llrs < 0.0).sum() / len(llrs):.2f}, "
-                    f"the median if negative log likelihood ratios is {np.median(llrs[llrs < 0.0]):.2e}, "
+                    "the median if negative log likelihood ratios "
+                    f"is {np.median(llrs[llrs < 0.0]):.2e}, "
                     f"there might be a problem in your fitting.",
                 )
             if len(llrs) < 1000:


### PR DESCRIPTION
For shape parameters such as the WIMP mass, we haven't implemented anything that would allow resetting its nominal value after initialization. However, this is done to obtain the ``poi_rate_multiplier`` for a given ``poi_expectation``, which means that the poi_rate_multiplier values corresponding to a given threshold might be wrong in the end.
I did the following to fix this issue and prevent us from running into a similar issue in the future:
  - Initialize a runner for each runner_arg in the ``NeymanConstructor``. This takes a bit longer and may sometimes be overkill but it works.
  - Introduce a derived boolean property for a parameter called ``static`` (see #81 ), which is true if the parameter is
    - not fittable
    - neither a livetime nor rate (ptype)
    - has no blueice anchors
  - If one tries to override the nominal value of a static parameter or call parameters with a value for it that is different to its nominal value, alea will throw an error.