### PR TITLE
Get expectation values per likelihood term

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -194,11 +194,10 @@ class BlueiceExtendedModel(StatisticalModel):
                 ret[ll_name][n] = mu
         if not per_likelihood_term:
             # sum over sources with same names of all likelihood terms
-            all_source_names = [ret[ll_name].keys() for ll_name in ret.keys()]
-            all_source_names = set().union(*all_source_names)
+            all_source_names = {name for sublist in ret.values() for name in sublist}
             ret = {
                 n: sum([ret[ll_name].get(n, 0) for ll_name in ret.keys()]) for n in all_source_names
-            }
+            }  # type: ignore
 
         return ret
 

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -196,7 +196,15 @@ class BlueiceExtendedModel(StatisticalModel):
             # sum over sources with same names of all likelihood terms
             all_source_names = [ret[ll_name].keys() for ll_name in ret.keys()]
             all_source_names = set().union(*all_source_names)
-            ret = {n: sum([ret[ll_name].get(n, 0) for ll_name in ret.keys()]) for n in all_source_names}
+            ret = {
+                n: sum(
+                    [
+                        ret[ll_name].get(n, 0)
+                        for ll_name in ret.keys()
+                    ]
+                )
+                for n in all_source_names
+            }
 
         return ret
 

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -197,7 +197,8 @@ class BlueiceExtendedModel(StatisticalModel):
             # sum over sources with same names of all likelihood terms
             all_source_names = {name for sublist in ret.values() for name in sublist}
             ret = {
-                n: sum([ret[ll_name].get(n, 0.) for ll_name in ret.keys()]) for n in all_source_names
+                n: sum([ret[ll_name].get(n, 0.0) for ll_name in ret.keys()])
+                for n in all_source_names
             }  # type: ignore
 
         return ret

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -197,9 +197,9 @@ class BlueiceExtendedModel(StatisticalModel):
             # sum over sources with same names of all likelihood terms
             all_source_names = {name for sublist in ret.values() for name in sublist}
             ret = {
-                n: sum([ret[ll_name].get(n, 0.0) for ll_name in ret.keys()])
+                n: sum([ret[ll_name].get(n, 0.0) for ll_name in ret.keys()])  # type: ignore
                 for n in all_source_names
-            }  # type: ignore
+            }
 
         return ret
 

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -197,7 +197,7 @@ class BlueiceExtendedModel(StatisticalModel):
             # sum over sources with same names of all likelihood terms
             all_source_names = {name for sublist in ret.values() for name in sublist}
             ret = {
-                n: sum([ret[ll_name].get(n, 0) for ll_name in ret.keys()]) for n in all_source_names
+                n: sum([ret[ll_name].get(n, 0.) for ll_name in ret.keys()]) for n in all_source_names
             }  # type: ignore
 
         return ret

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -197,13 +197,7 @@ class BlueiceExtendedModel(StatisticalModel):
             all_source_names = [ret[ll_name].keys() for ll_name in ret.keys()]
             all_source_names = set().union(*all_source_names)
             ret = {
-                n: sum(
-                    [
-                        ret[ll_name].get(n, 0)
-                        for ll_name in ret.keys()
-                    ]
-                )
-                for n in all_source_names
+                n: sum([ret[ll_name].get(n, 0) for ll_name in ret.keys()]) for n in all_source_names
             }
 
         return ret

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -153,7 +153,8 @@ class BlueiceExtendedModel(StatisticalModel):
             kwargs: Named parameters
 
         Returns:
-            dict: Dictionary of expectation values
+            dict: Dictionary of expectation values. If per_likelihood_term is True, the dictionary
+                has the form {likelihood_name: {source_name: expectation_value, ...}, ...}.
 
         Caution:
             The function silently drops parameters it can't handle!

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -97,6 +97,23 @@ class TestBlueiceExtendedModel(TestCase):
             for k, v in expectation_values.items():
                 self.assertEqual(v * scaling_factor, new_expectation_values[k])
 
+    def test_get_expectation_values_per_likelihood_term(self):
+        """Test of the get_expectation_values method with per_likelihood=True."""
+        self.set_new_models()
+        for model in self.models:
+            vals_per = model.get_expectation_values(per_likelihood_term=True)
+            vals_total = model.get_expectation_values(per_likelihood_term=False)
+
+            # Manually sum up the per_likelihood_term expectation values
+            summed_vals = {}
+            for term in vals_per.values():
+                for key, value in term.items():
+                    summed_vals[key] = summed_vals.get(key, 0) + value
+
+            # Check whether the summed values are equal to the total values
+            for key, summed_val in summed_vals.items():
+                self.assertEqual(summed_val, vals_total[key])
+
     def test_generate_data(self):
         """Test of the generate_data method."""
         for model, n in zip(self.models, self.n_likelihood_terms):


### PR DESCRIPTION
This PR adds additional functionality to the `get_expectation_values` method in the `BlueiceExtendedModel`. By default, the expectation values for the same source are summed over all likelihood terms. This remains to be the default, however now you can also get a dict of a dict, which contains the expectation values for each lieklihood term individually.

### Example:

```python
from alea import BlueiceExtendedModel
model = BlueiceExtendedModel.from_config("unbinned_wimp_statistical_model.yaml")

print(model.get_expectation_values())
# out: {'wimp': 12.0, 'er': 440.0}

print(model.get_expectation_values(per_likelihood_term=True))
# {'sr0': {'er': 40.0, 'wimp': 2.0}, 'sr1': {'er': 400.0, 'wimp': 10.0}}

```