### PR TITLE
Prevent arguments to submission variations being changed by deepcopy-ing them. 

### DIFF
--- a/alea/utils.py
+++ b/alea/utils.py
@@ -449,7 +449,7 @@ def convert_variations(variations: dict, iteration) -> list:
         if not isinstance(v, list):
             raise ValueError(f"variations {k} must be a list, not {v} with {type(v)}")
         variations[k] = expand_grid_dict(v)
-    result = [dict(zip(variations, t)) for t in iteration(*variations.values())]
+    result = [dict(zip(variations, deepcopy(t))) for t in iteration(*variations.values())]
     if result:
         return result
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from alea.utils import (
     clip_limits,
     can_expand_grid,
     expand_grid_dict,
+    convert_to_vary,
     deterministic_hash,
 )
 
@@ -71,6 +72,21 @@ class TestUtils(TestCase):
                 {"a": 1, "b": 4},
                 {"a": 2, "b": 3},
                 {"a": 2, "b": 4},
+            ],
+        )
+
+    def test_convert_to_vary(self):
+        """Test of the convert_to_zip function."""
+        varied = convert_to_vary({"a": [1, 2], "b": [{"c": 3}, {"c": 4}]})
+        self.assertNotEqual(id(varied[0]["b"]), id(varied[2]["b"]))
+        self.assertNotEqual(id(varied[1]["b"]), id(varied[3]["b"]))
+        self.assertEqual(
+            varied,
+            [
+                {"a": 1, "b": {"c": 3}},
+                {"a": 1, "b": {"c": 4}},
+                {"a": 2, "b": {"c": 3}},
+                {"a": 2, "b": {"c": 4}},
             ],
         )
 


### PR DESCRIPTION
Without deepcopy, the dictionary inside returned list of function `convert_variations` will be entangled:

```
>>> convert_to_vary({"a": [1, 2], "b": [{"c": 3}, {"c": 4}]}) #  referred as `result`
[{'a': 1, 'b': {'c': 3}}, {'a': 1, 'b': {'c': 4}}, {'a': 2, 'b': {'c': 3}}, {'a': 2, 'b': {'c': 4}}]
```

When you modify the `result[0]['b']`, without this PR, `result[2]['b']` will also be changed, because only the address is shallowly copied.

This PR is split from https://github.com/XENONnT/alea/pull/103.