### PR TITLE
Read poi and expectation directly from `output_filename` to accelerate `NeymanConstructor`

### DIFF
--- a/alea/model.py
+++ b/alea/model.py
@@ -255,7 +255,7 @@ class StatisticalModel:
             parameter_values: values of the parameters
 
         """
-        return NotImplementedError("get_expectation_values is optional to implement")
+        raise NotImplementedError("get_expectation_values is optional to implement")
 
     @property
     def nominal_expectation_values(self):

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -2,6 +2,7 @@ import warnings
 from typing import List, Dict, Callable, Optional, Union, cast
 from copy import deepcopy
 from pydoc import locate
+import itertools
 
 import numpy as np
 import scipy.stats as stats
@@ -138,10 +139,30 @@ class BlueiceExtendedModel(StatisticalModel):
         ll_index = self.likelihood_names.index(likelihood_name)
         return self.likelihood_list[ll_index].source_name_list
 
+    def get_all_source_name(self) -> set:
+        """Return a set of possible source names from all likelihood terms.
+
+        Args:
+            likelihood_name (str): Name of the likelihood.
+
+        Returns:
+            set: set of source names.
+
+        """
+        source_name = set(
+            itertools.chain.from_iterable([ll.source_name_list for ll in self.likelihood_list[:-1]])
+        )
+        return source_name
+
     @property
     def likelihood_list(self) -> List:
         """Return a list of likelihood terms."""
         return self._likelihood.likelihood_list
+
+    @property
+    def likelihood_parameters(self) -> List:
+        """Return a list of likelihood parameters."""
+        return self._likelihood.likelihood_parameters
 
     def get_expectation_values(self, per_likelihood_term=False, **kwargs) -> dict:
         """Return total expectation values (summed over all likelihood terms with the same name)
@@ -179,9 +200,9 @@ class BlueiceExtendedModel(StatisticalModel):
 
         # ancillary likelihood does not contribute
         for ll_term, ll_name, parameter_names, livetime_parameter in zip(
-            self_copy._likelihood.likelihood_list[:-1],
+            self_copy.likelihood_list[:-1],
             self_copy.likelihood_names[:-1],
-            self_copy._likelihood.likelihood_parameters,
+            self_copy.likelihood_parameters,
             self_copy.livetime_parameter_names,
         ):
             ret[ll_name] = {}

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -2,7 +2,6 @@ import warnings
 from typing import List, Dict, Callable, Optional, Union, cast
 from copy import deepcopy
 from pydoc import locate
-import itertools
 
 import numpy as np
 import scipy.stats as stats
@@ -139,30 +138,10 @@ class BlueiceExtendedModel(StatisticalModel):
         ll_index = self.likelihood_names.index(likelihood_name)
         return self.likelihood_list[ll_index].source_name_list
 
-    def get_all_source_name(self) -> set:
-        """Return a set of possible source names from all likelihood terms.
-
-        Args:
-            likelihood_name (str): Name of the likelihood.
-
-        Returns:
-            set: set of source names.
-
-        """
-        source_name = set(
-            itertools.chain.from_iterable([ll.source_name_list for ll in self.likelihood_list[:-1]])
-        )
-        return source_name
-
     @property
     def likelihood_list(self) -> List:
         """Return a list of likelihood terms."""
         return self._likelihood.likelihood_list
-
-    @property
-    def likelihood_parameters(self) -> List:
-        """Return a list of likelihood parameters."""
-        return self._likelihood.likelihood_parameters
 
     def get_expectation_values(self, per_likelihood_term=False, **kwargs) -> dict:
         """Return total expectation values (summed over all likelihood terms with the same name)
@@ -200,9 +179,9 @@ class BlueiceExtendedModel(StatisticalModel):
 
         # ancillary likelihood does not contribute
         for ll_term, ll_name, parameter_names, livetime_parameter in zip(
-            self_copy.likelihood_list[:-1],
+            self_copy._likelihood.likelihood_list[:-1],
             self_copy.likelihood_names[:-1],
-            self_copy.likelihood_parameters,
+            self_copy._likelihood.likelihood_parameters,
             self_copy.livetime_parameter_names,
         ):
             ret[ll_name] = {}

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -340,7 +340,12 @@ class Runner:
         metadata["common_hypothesis"] = self.common_hypothesis
         metadata["generate_values"] = self.generate_values
         metadata["nominal_values"] = self.nominal_values
-        metadata["expectation_values"] = self.model.get_expectation_values(**self.generate_values)
+        try:
+            metadata["expectation_values"] = self.model.get_expectation_values(
+                **self.generate_values
+            )
+        except NotImplementedError:
+            metadata["expectation_values"] = {}
 
         array_metadatas = [{"hypotheses_values": ea} for ea in self._hypotheses_values]
         numpy_arrays_and_names = [(r, rn) for r, rn in zip(results, result_names)]

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -119,6 +119,7 @@ class Runner:
             statistical_model_args = {}
         # nominal_values is keyword argument
         self.nominal_values = nominal_values if nominal_values else {}
+        # initialize nominal_values only once
         statistical_model_args["nominal_values"] = self.nominal_values
         # likelihood_config is keyword argument, because not all statistical model needs it
         statistical_model_args["likelihood_config"] = likelihood_config
@@ -338,6 +339,8 @@ class Runner:
         metadata["poi"] = self.poi
         metadata["common_hypothesis"] = self.common_hypothesis
         metadata["generate_values"] = self.generate_values
+        metadata["nominal_values"] = self.nominal_values
+        metadata["expectation_values"] = self.model.get_expectation_values(**self.generate_values)
 
         array_metadatas = [{"hypotheses_values": ea} for ea in self._hypotheses_values]
         numpy_arrays_and_names = [(r, rn) for r, rn in zip(results, result_names)]

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -21,6 +21,7 @@ from alea.utils import (
     load_json,
     asymptotic_critical_value,
     deterministic_hash,
+    search_filename_pattern,
 )
 
 
@@ -166,15 +167,10 @@ class NeymanConstructor(SubmitterLocal):
             }
 
             # read the likelihood ratio
-            output_filename = runner_args["output_filename"].format(**needed_kwargs)
-            # try to add a * to the output_filename to read all the files
-            fpat_split = os.path.splitext(output_filename)
-            _output_filename = fpat_split[0] + "_*" + fpat_split[1]
-            if len(sorted(glob(_output_filename))) != 0:
-                output_filename = _output_filename
-            output_filename_list = sorted(glob(output_filename))
-            if len(output_filename_list) == 0:
-                raise ValueError(f"Can not find any output file {output_filename}!")
+            output_filename_pattern = search_filename_pattern(
+                runner_args["output_filename"].format(**needed_kwargs)
+            )
+            output_filename_list = sorted(glob(output_filename_pattern))
 
             # read metadata including generate_values
             metadata_list = []
@@ -233,7 +229,7 @@ class NeymanConstructor(SubmitterLocal):
                     poi_expectation = _poi_expectation
 
             # read the likelihood ratio
-            results = toyfiles_to_numpy(output_filename)
+            results = toyfiles_to_numpy(output_filename_pattern)
             llfree = results[free_name]["ll"]
             lltrue = results[true_name]["ll"]
             llrs = 2.0 * (llfree - lltrue)

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -374,6 +374,28 @@ def add_i_batch(filename: str) -> str:
     return fpat_split[0] + "_{i_batch:d}" + fpat_split[1]
 
 
+def search_filename_pattern(filename: str) -> str:
+    """Return pattern for a given existing filename. This is needed because sometimes the filename
+    is not appended by "_{i_batch:d}". We need to distinguish between the two cases and return the
+    correct pattern.
+
+    Returns:
+        str: existing pattern for filename, either filename or filename w/ inserted "_*"
+
+    """
+    # try to add a * to the filename to read all the files
+    fpat_split = os.path.splitext(filename)
+    _filename = fpat_split[0] + "_*" + fpat_split[1]
+    if len(sorted(glob(_filename))) != 0:
+        pattern = _filename
+    else:
+        pattern = filename
+    filename_list = sorted(glob(pattern))
+    if len(filename_list) == 0:
+        raise ValueError(f"Can not find any output file {filename}!")
+    return pattern
+
+
 def can_expand_grid(variations: dict) -> bool:
     """Check if variations can be expanded into a grid.
 

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -13,6 +13,8 @@ from base64 import b32encode
 from collections.abc import Mapping
 from typing import Any, List, Dict, Tuple, Optional, Union, cast, get_args, get_origin
 
+import h5py
+
 # These imports are needed to evaluate strings
 import numpy  # noqa: F401
 import numpy as np  # noqa: F401
@@ -394,6 +396,22 @@ def search_filename_pattern(filename: str) -> str:
     if len(filename_list) == 0:
         raise ValueError(f"Can not find any output file {filename}!")
     return pattern
+
+
+def get_metadata(output_filename_pattern: str) -> list:
+    """Get metadata from output files."""
+    output_filename_list = sorted(glob(output_filename_pattern))
+    metadata_list = []
+    for _output_filename in output_filename_list:
+        with h5py.File(_output_filename, "r", libver="latest", swmr=True) as ipt:
+            metadata = dict(
+                zip(
+                    ipt.attrs.keys(),
+                    [json.loads(ipt.attrs[key]) for key in ipt.attrs.keys()],
+                )
+            )
+        metadata_list.append(metadata)
+    return metadata_list
 
 
 def can_expand_grid(variations: dict) -> bool:


### PR DESCRIPTION
We do not need to initialize runner for each **{**nominal_values, **generate_values}, but we can read the poi directly from toymc files `output_filename`.

This was initially an idea from @hammannr, https://github.com/XENONnT/alea/pull/100#issuecomment-1784817837.

0. Save expectation_values to metadata
1. First figure out whether it is single `output_filename` mode or multiple(batch) `output_filename` mode
2. Read metadata from the list of `output_filename` and make sure that the metadata is the same in the list
3. Take the first entry of the metadata list as metadata
4. Assert it contains poi, which is guaranteed by https://github.com/XENONnT/alea/blob/80bd030205ed299fd26aedaddfdc31f3ee5849bb/alea/runner.py#L340
5. Read poi and expectation_values from metadata
6. Read poi_expectation from expectation_values

This PR is superseding https://github.com/XENONnT/alea/pull/103.