### PR TITLE
Make sure values of parameters that need re-initialization are not changed

### DIFF
--- a/alea/examples/configs/unbinned_wimp_statistical_model.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model.yaml
@@ -1,7 +1,6 @@
 parameter_definition:
   wimp_mass:
     nominal_value: 50
-    ptype: shape
     fittable: false
     description: WIMP mass in GeV/c^2
     blueice_anchors:

--- a/alea/examples/configs/unbinned_wimp_statistical_model.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model.yaml
@@ -3,8 +3,6 @@ parameter_definition:
     nominal_value: 50
     fittable: false
     description: WIMP mass in GeV/c^2
-    blueice_anchors:
-      - 50
 
   livetime_sr0:
     nominal_value: 0.2

--- a/alea/model.py
+++ b/alea/model.py
@@ -95,7 +95,7 @@ class StatisticalModel:
         self._confidence_interval_kind = confidence_interval_kind
         self.confidence_interval_threshold = confidence_interval_threshold
         self.asymptotic_dof = asymptotic_dof
-        nominal_values = kwargs.get("nominal_values", {})
+        nominal_values = kwargs.get("nominal_values", None)
         self._define_parameters(parameter_definition, nominal_values)
 
         self._check_ll_and_generate_data_signature()
@@ -105,12 +105,16 @@ class StatisticalModel:
         if parameter_definition is None:
             self.parameters = Parameters()
         elif isinstance(parameter_definition, dict):
-            for name, definition in parameter_definition.items():
-                if name in nominal_values:
-                    definition["nominal_value"] = nominal_values[name]
+            # if nominal_values are given, overwrite the ones in parameter_definition
+            if nominal_values is not None:
+                for name, definition in parameter_definition.items():
+                    if name in nominal_values:
+                        definition["nominal_value"] = nominal_values[name]
             self.parameters = Parameters.from_config(parameter_definition)
         elif isinstance(parameter_definition, list):
             self.parameters = Parameters.from_list(parameter_definition)
+            if nominal_values is not None:
+                self.parameters.set_nominal_values(**nominal_values)
         else:
             raise RuntimeError("parameter_definition must be dict or list")
 

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -438,7 +438,7 @@ class BlueiceExtendedModel(StatisticalModel):
         If no ptype is specified, set the default ptype "needs_reinit".
 
         """
-        allowed_ptypes = ["rate", "shape", "efficiency", "livetim", "needs_reinit"]
+        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit"]
         default_ptype = "needs_reinit"
         for p in self.parameters:
             if p.ptype is None:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -60,6 +60,7 @@ class BlueiceExtendedModel(StatisticalModel):
         ]
         self.livetime_parameter_names += [None]  # ancillary likelihood
         self.data_generators = self._build_data_generators()
+        self._set_default_ptype()
 
     @classmethod
     def from_config(cls, config_file_path: str, **kwargs) -> "BlueiceExtendedModel":
@@ -430,6 +431,23 @@ class BlueiceExtendedModel(StatisticalModel):
                 " must be constrained to be finite"
             )
         ll.add_shape_parameter(efficiency_name, anchors=(limits[0], limits[1]))
+
+    def _set_default_ptype(self):
+        """Check if all parameters have a ptype that is in the list of allowed ptypes.
+
+        If no ptype is specified, set the default ptype "needs_reinit".
+
+        """
+        allowed_ptypes = ["rate", "shape", "efficiency", "livetim", "needs_reinit"]
+        default_ptype = "needs_reinit"
+        for p in self.parameters:
+            if p.ptype is None:
+                p.ptype = default_ptype
+            elif p.ptype not in allowed_ptypes:
+                raise ValueError(
+                    f"Parameter {p.name} has ptype {p.ptype} which is not in the list of "
+                    f"allowed ptypes: {allowed_ptypes}."
+                )
 
     def store_real_data(self, file_name: str, real_data_list: list, metadata=None):
         """Store real data in a file with toydata format.

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -339,6 +339,14 @@ class Parameters:
             k: i.nominal_value for k, i in self.parameters.items() if i.nominal_value is not None
         }
 
+    def set_nominal_values(self, **nominal_values):
+        """Set the nominal values for parameters.
+        Keyword Args:
+            nominal_values (dict): A dict of parameter names and values.
+        """
+        for name, value in nominal_values.items():
+            self.parameters[name].nominal_value = value
+
     def set_fit_guesses(self, **fit_guesses):
         """Set the fit guesses for parameters.
 

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -60,6 +60,8 @@ class Parameter:
         self.fit_guess = fit_guess
         self.description = description
 
+        self._check_parameter_consistency()
+
     def __repr__(self) -> str:
         parameter_str = ", ".join([f"{k}={v}" for k, v in self.__dict__.items() if v is not None])
         _repr = f"{self.__class__.__module__}.{self.__class__.__qualname__}"
@@ -169,6 +171,20 @@ class Parameter:
             raise ValueError(
                 f"parameter_interval_bounds {value} not within "
                 f"fit_limits {self.fit_limits} for parameter {self.name}."
+            )
+
+    def _check_parameter_consistency(self):
+        """Check if parameter is consistent."""
+        if self.fittable and self.needs_reinit:
+            warnings.warn(
+                f"Parameter {self.name} is fittable and needs re-initialization. "
+                "This may cause unexpected behaviour."
+            )
+        if (self.blueice_anchors is not None) and self.needs_reinit:
+            raise ValueError(
+                f"Parameter {self.name} needs re-initialization but has "
+                "blueice_anchors defined. "
+                "This may cause unexpected behaviour."
             )
 
 

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -24,8 +24,6 @@ class Parameter:
             for any value in between.
         fit_limits (Tuple[float, float], optional (default=None)):
             The limits for fitting the parameter.
-        static (bool, optional (default=False)):
-            If True, the parameter is static and cannot be changed from its nominal value.
         parameter_interval_bounds (Tuple[float, float], optional (default=None)):
             Limits for computing confidence intervals.
         fit_guess (float, optional (default=None)): The initial guess for fitting the parameter.
@@ -45,7 +43,6 @@ class Parameter:
         relative_uncertainty: Optional[bool] = None,
         blueice_anchors: Optional[List] = None,
         fit_limits: Optional[Tuple] = None,
-        static: Optional[bool] = False,
         parameter_interval_bounds: Optional[Tuple[float, float]] = None,
         fit_guess: Optional[float] = None,
         description: Optional[str] = None,
@@ -59,7 +56,6 @@ class Parameter:
         self.uncertainty = uncertainty
         self.blueice_anchors = blueice_anchors
         self.fit_limits = fit_limits
-        self.static = static
         self.parameter_interval_bounds = parameter_interval_bounds
         self.fit_guess = fit_guess
         self.description = description
@@ -134,13 +130,21 @@ class Parameter:
 
     @nominal_value.setter
     def nominal_value(self, value: Optional[float]) -> None:
-        if self.static and (value != self._nominal_value):
+        if self.needs_reinit and (value != self._nominal_value):
             raise ValueError(
-                f"{self.name} is a static parameter. "
-                "You can't change its nominal value "
+                f"{self.name} is a parameter that requires re-initialization "
+                "its nominal value. "
                 f"(tried to override nominal value {self._nominal_value} with {value})."
             )
         self._nominal_value = value
+
+    @property
+    def needs_reinit(self) -> bool:
+        """Return True if the parameter needs re-initialization (for ptype `needs_reinit`)."""
+        needs_reinit = False
+        if self.ptype == "needs_reinit":
+            needs_reinit = True
+        return needs_reinit
 
     def __eq__(self, other: object) -> bool:
         """Return True if all attributes are equal."""
@@ -374,10 +378,10 @@ class Parameters:
 
         for name, param in self.parameters.items():
             new_val = kwargs.get(name, None)
-            if param.static and (new_val != param.nominal_value) and (new_val is not None):
+            if param.needs_reinit and new_val != param.nominal_value and new_val is not None:
                 raise ValueError(
-                    f"Parameter {name} is static. "
-                    "You can't change its value from its nominal value "
+                    f"{name} is a parameter that requires re-initialization "
+                    "its nominal value. "
                     f"(tried to override nominal value {param.nominal_value} "
                     f"with {new_val}).)"
                 )

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -133,7 +133,7 @@ class Parameter:
         if self.needs_reinit and (value != self._nominal_value):
             raise ValueError(
                 f"{self.name} is a parameter that requires re-initialization "
-                "its nominal value. "
+                "to change its nominal value "
                 f"(tried to override nominal value {self._nominal_value} with {value})."
             )
         self._nominal_value = value
@@ -381,9 +381,9 @@ class Parameters:
             if param.needs_reinit and new_val != param.nominal_value and new_val is not None:
                 raise ValueError(
                     f"{name} is a parameter that requires re-initialization "
-                    "its nominal value. "
+                    "to override its nominal value "
                     f"(tried to override nominal value {param.nominal_value} "
-                    f"with {new_val}).)"
+                    f"with {new_val})."
                 )
             if (return_fittable and param.fittable) or (not return_fittable):
                 values[name] = new_val if new_val is not None else param.nominal_value

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -203,3 +203,8 @@ class TestBlueiceExtendedModel(TestCase):
             # check that a ValueError is raised when calling the parameters with another value
             with self.assertRaises(ValueError):
                 model.parameters(wimp_mass=1)
+            with self.assertRaises(ValueError):
+                model.get_expectation_values(wimp_mass=1)
+            model.data = model.generate_data()
+            with self.assertRaises(ValueError):
+                model.fit(wimp_mass=1)

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -183,3 +183,14 @@ class TestBlueiceExtendedModel(TestCase):
             model.data = toydata[0]
             model.fit()
             remove(self.toydata_filename)
+
+    def test_needs_reinit(self):
+        """Test of the needs_reinit property of parameters."""
+        for model in self.models:
+            self.assertTrue(model.parameters["wimp_mass"].needs_reinit)
+            # check that a ValueError is raised when trying to set the nominal parameter
+            with self.assertRaises(ValueError):
+                model.parameters["wimp_mass"].nominal_value = 1
+            # check that a ValueError is raised when calling the parameters with another value
+            with self.assertRaises(ValueError):
+                model.parameters(wimp_mass=1)


### PR DESCRIPTION
As mentioned in #105 this PR improves the implementation of parameters that require the model to be re-initialized (such as the wimp_mass in case it is not treated as shape parameter.

For this, I added the `ptype` `"needs_reinit"`, which sets a related boolean property. The behaviour is then the same as before with the `static` boolean.

In the blueice extended model we now check that all ptypes are known and in case none are provided we fall back to needs_reinit.