### PR TITLE
Update `hypotheses` and `common_hypothesis` by `pre_process_poi`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ debug.py
 .DS_Store
 docs/source/reference/release_notes.rst
 .vscode
+.hypothesis

--- a/alea/examples/configs/unbinned_wimp_running.yaml
+++ b/alea/examples/configs/unbinned_wimp_running.yaml
@@ -13,7 +13,7 @@ computation_options:
       }
     in_common:
       {
-        hypotheses: ["free", "zero", "true"],
+        hypotheses: ["free", "zero", "true", {"poi_expectation": 15}],
         output_filename: "toymc_power_wimp_mass_{wimp_mass:d}_poi_expectation_{poi_expectation:.2f}.ii.h5",
         n_mc: 5000,
         n_batch: 40,

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -184,8 +184,7 @@ class Runner:
         else:
             self.input_poi_expectation = False
         # update poi according to poi_expectation
-        value = self.pre_process_poi(value, "generate_values")
-        self._generate_values = value
+        self._generate_values = self.pre_process_poi(value, "generate_values")
 
     @property
     def common_hypothesis(self) -> Dict[str, float]:
@@ -194,8 +193,7 @@ class Runner:
     @common_hypothesis.setter
     def common_hypothesis(self, value: Dict[str, float]) -> None:
         # update poi according to poi_expectation
-        value = self.pre_process_poi(value, "common_hypothesis")
-        self._common_hypothesis = value
+        self._common_hypothesis = self.pre_process_poi(value, "common_hypothesis")
 
     @property
     def hypotheses(self) -> list:

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -164,10 +164,12 @@ class Runner:
             statistical_model_args.get("asymptotic_dof", 1),
         )
 
-    def pre_process_poi(self, value, name):
-        """Pre-process of poi_expectation."""
+    def pre_process_poi(self, value, attribute_name):
+        """Pre-process of poi_expectation for some attributes of runner."""
         if not all([isinstance(v, (float, int)) for v in value.values()]):
-            raise ValueError(f"{name} should be a dict of float! But {value} is provided.")
+            raise ValueError(
+                f"{attribute_name} should be a dict of float! But {value} is provided."
+            )
         # update poi according to poi_expectation
         if "poi_expectation" in value:
             value = self.update_poi(self.model, self.poi, value, self.nominal_values)


### PR DESCRIPTION
Previously only the `generate_values` are updated by `update_poi`:

https://github.com/XENONnT/alea/blob/cee1e71858fa967ecb00f123dc43d0c9b4127d91/alea/runner.py#L172-L181

This PR also updates `"poi_expectation"` in `hypotheses` and `common_hypothesis`.