### PR TITLE
Make model histograms accessible

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -251,12 +251,15 @@ class BlueiceExtendedModel(StatisticalModel):
 
         # compute the pdfs
         self.data_generators[ll_index].compute_pdfs_and_mus(**generate_values)
+        source_histograms = self.data_generators[ll_index].source_histograms
 
         if multiply_mus:
-            # FIXME
-            raise NotImplementedError
+            mus = self.data_generators[ll_index].mus
+            for source_name, hist in source_histograms.items():
+                source_index = self.get_source_name_list(likelihood_name).index(source_name)
+                hist.histogram *= mus[source_index]
 
-        return self.data_generators[ll_index].source_histograms
+        return source_histograms
 
     def _process_blueice_config(self, config, template_folder_list):
         """Process the blueice config from config."""

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -8,7 +8,6 @@ import scipy.stats as stats
 from blueice.likelihood import LogAncillaryLikelihood, LogLikelihoodSum
 from inference_interface import dict_to_structured_array, structured_array_to_dict
 
-# import multihist
 from alea.model import StatisticalModel
 from alea.parameters import Parameters
 from alea.simulators import BlueiceDataGenerator

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -258,50 +258,6 @@ class BlueiceExtendedModel(StatisticalModel):
 
         return self.data_generators[ll_index].source_histograms
 
-        # # prepare the generate_values, WARNING: This silently drops parameters it can't handle!
-        # generate_values = self.parameters(**kwargs)  # kwarg or nominal value
-        # parameter_names = self.likelihood_parameters[likelihood_index]
-        # livetime_parameter = self.livetime_parameter_names[likelihood_index]
-        # call_args = {k: i for k, i in generate_values.items() if k in parameter_names}
-        # if livetime_parameter is not None:
-        #     call_args["livetime_days"] = generate_values[livetime_parameter]
-
-        # we will set fake data to the likelihood term so we need to copy it
-        # ll_term = deepcopy(self.likelihood_list[likelihood_index])
-
-        # set fake data as the center of each bin
-        # analysis_space = ll_term.base_model.config["analysis_space"]
-        # h_template = multihist.Histdd(dimensions=analysis_space)
-        # bin_centers = []
-        # dtype = []
-        # for (name, bin_edges) in analysis_space:
-        #     dtype.append((name, float))
-        #     bin_centers.append(0.5 * (bin_edges[:-1] + bin_edges[1:]))
-
-        # data_binc = np.zeros(np.product(h_template.histogram.shape), dtype=dtype)
-        # for i, l in enumerate(itertools.product(*bin_centers)):
-        #     for n, v in zip([dt[0] for dt in dtype], l):
-        #         data_binc[n][i] = v
-
-        # ll_term.set_data(data_binc)
-
-        # # Evaluate the pdf and cast it to a multihist
-        # _, mus, ps = ll_term(full_output=True, **call_args)
-        # source_names = [s.name for s in ll_term.base_model.sources]
-
-        # hs = {}
-        # for source_name, p in zip(source_names, ps):
-        #     h = deepcopy(h_template)
-        #     h.histogram = p.reshape(h_template.histogram.shape)
-
-        #     h.histogram *= h.bin_volumes()
-        #     if multiply_mus:
-        #         h.histogram *= mus[source_names.index(source_name)]
-        #     hs[source_name] = h
-
-        # return hs
-        # return {}
-
     def _process_blueice_config(self, config, template_folder_list):
         """Process the blueice config from config."""
         blueice_config = adapt_likelihood_config_for_blueice(config, template_folder_list)

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -212,15 +212,15 @@ class BlueiceExtendedModel(StatisticalModel):
         return ret
 
     def get_source_histograms(self, likelihood_name: str, multiply_mus=False, **kwargs) -> dict:
-        """Return the pdf for a given source and likelihood term.
+        """Return the pdfs or histograms of all sources for a given likelihood term.
 
         Args:
             likelihood_name (str): Name of the likelihood term.
-            multiply_mus (bool): If True, multiply the pdf with the mus.
+            multiply_mus (bool): If True, multiply the pdfs/histograms with the expecftation values.
             kwargs: Named parameters.
 
         Returns:
-            dict: Dictionary of multihist objects for each source.
+            dict: Dictionary containing a multihist object for each source.
 
         """
         if likelihood_name not in self.likelihood_names:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -228,7 +228,7 @@ class BlueiceExtendedModel(StatisticalModel):
             raise ValueError(f"Likelihood {likelihood_name} not found.")
         elif likelihood_name == "ancillary":
             raise ValueError("No source histograms for ancillary likelihood.")
-        
+
         ll_index = self.likelihood_names.index(likelihood_name)
 
         # prepare generate_values

--- a/alea/simulators.py
+++ b/alea/simulators.py
@@ -60,9 +60,9 @@ class BlueiceDataGenerator:
                 data_binc[n][i] = v
 
         ll.set_data(data_binc)
-        source_histograms = []
-        for i in range(len(ll.base_model.sources)):
-            source_histograms.append(mh.Histdd(dimensions=analysis_space))
+        source_histograms = {}
+        for s in ll.base_model.sources:
+            source_histograms[s.name] = mh.Histdd(dimensions=analysis_space)
 
         self.ll = ll
         self.bincs = bincs
@@ -98,6 +98,7 @@ class BlueiceDataGenerator:
             The dtype follows self.dtype.
 
         """
+        # TODO: I changed source_histograms to be a dict, so this needs to be updated
         self.compute_pdfs(filter_kwargs=filter_kwargs, **kwargs)
 
         if n_toys is not None:
@@ -124,7 +125,7 @@ class BlueiceDataGenerator:
                 i_write += n_source
         return r_data
 
-    def compute_pdfs(self, filter_kwargs=True, **kwargs) -> None:
+    def compute_pdfs_and_mus(self, filter_kwargs=True, **kwargs) -> None:
         """Compute PDFs of the sources for the given parameters.
 
         Args:

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -77,7 +77,7 @@ class TestBlueiceExtendedModel(TestCase):
             for ll_t in config["likelihood_config"]["likelihood_terms"]:
                 _source_names.update([s["name"] for s in ll_t["sources"]])
             source_names = model.all_source_names
-            self.assertEqual(source_names, _source_names)
+            self.assertEqual(source_names, sorted(_source_names))
 
     def test_expectation_values(self):
         """Test of the expectation_values method."""

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -223,19 +223,14 @@ class TestBlueiceExtendedModel(TestCase):
                     source_index = ll_term.source_name_list.index(s_name)
                     blueice_source = ll_term.base_model.sources[source_index]
                     blueice_hist = blueice_source._pdf_histogram.histogram
-                    np.testing.assert_almost_equal(blueice_hist, histogram,
-                                                   decimal=10)
+                    np.testing.assert_almost_equal(blueice_hist, histogram, decimal=10)
 
                 # check that expected_events boolean works
-                source_histograms = model.get_source_histograms(
-                    ll_name,
-                    expected_events=True
-                )
+                source_histograms = model.get_source_histograms(ll_name, expected_events=True)
                 for s_name, histogram in source_histograms.items():
                     mu = mus[ll_name][s_name]
                     sum_hist = histogram.n
-                    np.testing.assert_almost_equal(mu, sum_hist,
-                                                   decimal=4)
+                    np.testing.assert_almost_equal(mu, sum_hist, decimal=4)
 
             # check that model.likelihood_names[-1] fails
             with self.assertRaises(ValueError):

--- a/tests/test_template_source.py
+++ b/tests/test_template_source.py
@@ -14,3 +14,28 @@ class TestTemplateSource(TestCase):
         likelihood_config = model_configs["likelihood_config"]
         model = BlueiceExtendedModel(parameter_definition, likelihood_config)
         model.nominal_expectation_values
+
+    def test_wrong_analysis_space(self):
+        """Test whether initializing with a wrong analysis_space raises error."""
+        model_configs = load_yaml("unbinned_wimp_statistical_model_template_source_test.yaml")
+        parameter_definition = model_configs["parameter_definition"]
+        likelihood_config = model_configs["likelihood_config"]
+        # Change the analysis space to a wrong one
+        space = likelihood_config["likelihood_terms"][0]["analysis_space"]
+        # additive mismatch in cs1
+        space[0]["cs1"] = "np.linspace(1, 101, 51)"
+        space[1]["cs2"] = "np.geomspace(100, 100000, 51)"
+        with self.assertRaises(AssertionError):
+            _ = BlueiceExtendedModel(parameter_definition, likelihood_config)
+
+        # multiplicative mismatch in cs2
+        space[0]["cs1"] = "np.linspace(0, 100, 51)"
+        space[1]["cs2"] = "np.geomspace(101, 101000, 51)"
+        with self.assertRaises(AssertionError):
+            _ = BlueiceExtendedModel(parameter_definition, likelihood_config)
+
+        # If the dimensions are wrong we should get ValueError
+        space[0]["cs1"] = "np.linspace(0, 100, 50)"
+        space[1]["cs2"] = "np.geomspace(100, 100000, 51)"
+        with self.assertRaises(ValueError):
+            _ = BlueiceExtendedModel(parameter_definition, likelihood_config)


### PR DESCRIPTION
This PR adds a method `get_source_histograms` to the `BlueiceExtendedModel`, which returns the pdfs/histograms of a specific likelihood term. Similar to `get_expectation_values` it accepts all kwargs and modifies the templates accordingly (closes #74).

To implement this, I use the `BlueiceDataGenerator` since it already has everything we need for this task.

After implementing this, I also rewrote `get_expectation_values` via the data generator. This avoids the workaround, which involved making a deepcopy of the entire class and generating fake data. This was also by far the slowest part so this implementation is now much faster than before. In addition, it benefits from the fact that the results for the last kwargs are always cached. So if I generate toy data and then want to check the expectation values and histograms with the same `generate_values` I get the results "for free".


One open question I have, which I wanted to discuss with you is whether the default of `get_source_histogram` should be to return a dict of dicts containing the results for all likelihood terms (similar to `get_expectation_values(per_likelihood_term=True)`. I was undecided -- what do you think?

I'll add unittests once you had a first look and have no conceptual remarks 😊  