### PR TITLE
Make "piecewise" the default pdf interpolation

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -347,7 +347,23 @@ class BlueiceExtendedModel(StatisticalModel):
 
         """
         # last one is AncillaryLikelihood
-        return [BlueiceDataGenerator(ll_term) for ll_term in self.likelihood_list[:-1]]
+        data_generators = []
+        for ll_term in self.likelihood_list[:-1]:
+            methods = [s.config["pdf_interpolation_method"] for s in ll_term.base_model.sources]
+            # make sure that all sources have the same pdf_interpolation_method
+            if len(set(methods)) != 1:
+                raise ValueError("All sources must have the same pdf_interpolation_method.")
+            method = methods[0]
+            if method == "piecewise":
+                data_generators.append(BlueiceDataGenerator(ll_term))
+            elif method == "linear":
+                raise NotImplementedError(
+                    "Linear interpolation is not yet supported."
+                    " Choose piecewise as pdf_interpolation_method."
+                )
+            else:
+                raise ValueError(f"Unknown pdf_interpolation_method {method}.")
+        return data_generators
 
     def _ll(self, **generate_values) -> float:
         livetime_days = [generate_values.get(ln, None) for ln in self.livetime_parameter_names]

--- a/alea/template_source.py
+++ b/alea/template_source.py
@@ -45,6 +45,13 @@ class TemplateSource(HistogramPdfSource):
 
     """
 
+    def __init__(self, config: Dict, *args, **kwargs):
+        """Initialize the TemplateSource."""
+        # override the default interpolation method
+        if "pdf_interpolation_method" not in config:
+            config["pdf_interpolation_method"] = "piecewise"
+        super().__init__(config, *args, **kwargs)
+
     def _check_binning(self, h, histogram_info: str):
         """Check if the histogram"s bin edges are the same to analysis_space.
 


### PR DESCRIPTION
This PR makes `"piecewise"` the default pdf interpolation method. Before, the default was defined in blueice to `"linear"`, which is only in certain limits compatible with the `BlueiceDataGenerator`. The `BlueiceDataGenerator` is now only assigned if all sources have piecewise interpolation -- in the future we can add a suitable generator also for the linear interpolation case.