### PR TITLE
point away from alea for physics models

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 alea is a flexible statistical inference framework. The Python package is designed for constructing, handling, and fitting statistical models, computing confidence intervals and conducting sensitivity studies. It is primarily developed for the [XENONnT dark matter experiment](https://xenonexperiment.org/), but can be used for any statistical inference problem.
 
-Alea aims to model the statistical behaviour of an experiment, which again depends on your knowledge of the underlying physics-- this can range from the very simple, such as measuring a gaussian-distributed random variable, to complex likelihoods where each model component is created by physics simulations (GEANT4), fast detector simulations (for example [appletree](https://github.com/XENONnT/appletree/) for XENONnT) or a data-driven method.  
+Alea aims to model the statistical behaviour of an experiment, which again depends on your knowledge of the underlying physics-- this can range from the very simple, such as measuring a gaussian-distributed random variable, to complex likelihoods where each model component is created by physics simulations (GEANT4), fast detector simulations (for example [appletree](https://github.com/XENONnT/appletree/) for XENONnT) or a data-driven method.
 
 If you use alea in your research, please consider citing the software published on [zenodo](https://zenodo.org/badge/latestdoi/654100988).
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 alea is a flexible statistical inference framework. The Python package is designed for constructing, handling, and fitting statistical models, computing confidence intervals and conducting sensitivity studies. It is primarily developed for the [XENONnT dark matter experiment](https://xenonexperiment.org/), but can be used for any statistical inference problem.
 
+Alea aims to model the statistical behaviour of an experiment, which again depends on your knowledge of the underlying physics-- this can range from the very simple, such as measuring a gaussian-distributed random variable, to complex likelihoods where each model component is created by physics simulations (GEANT4), fast detector simulations (for example [appletree](https://github.com/XENONnT/appletree/) for XENONnT) or a data-driven method.  
+
 If you use alea in your research, please consider citing the software published on [zenodo](https://zenodo.org/badge/latestdoi/654100988).
 
 ## Installation


### PR DESCRIPTION
Several look to alea to understand our signal or background model, this adds a short text to point out that alea takes this from otherwhere