### PR TITLE
Enforce bins in config and template to match

### DIFF
--- a/alea/template_source.py
+++ b/alea/template_source.py
@@ -76,20 +76,15 @@ class TemplateSource(HistogramPdfSource):
             logging.debug("expected_bin_edges: " + str(expected_bin_edges))
             logging.debug("seen_bin_edges: " + str(seen_bin_edges))
             logging.debug("h.bin_edges type" + str(h.bin_edges))
+            err_msg = (
+                f"Axis {axis_i:d} of histogram {histogram_info} "
+                f"has bin edges {seen_bin_edges}, but expected {expected_bin_edges}."
+            )
             if len(seen_bin_edges) != len(expected_bin_edges):
-                raise ValueError(
-                    f"Axis {axis_i:d} of histogram {histogram_info} "
-                    f"has {len(seen_bin_edges)} bin edges, but expected {expected_bin_edges}."
-                )
-            try:
-                np.testing.assert_almost_equal(seen_bin_edges, expected_bin_edges, decimal=2)
-            except AssertionError:
-                logging.warn(
-                    f"Axis {axis_i:d} of histogram {histogram_info} "
-                    f"has bin edges {seen_bin_edges}, but expected {expected_bin_edges}. "
-                    "Since length matches, setting it expected values..."
-                )
-                h.bin_edges[axis_i] = expected_bin_edges
+                raise ValueError(err_msg)
+            np.testing.assert_almost_equal(
+                seen_bin_edges, expected_bin_edges, decimal=2, err_msg=err_msg
+            )
 
     @property
     def format_named_parameters(self):


### PR DESCRIPTION
So far, we only strictly enforced the lenghts of bin edges in config and template to match. I would suggest enforcing this also if values are off. In some cases the bin volumes are relevant and thus overriding the edges with wrong values might cause problems.