### PR TITLE
Make local submitter verbose

### DIFF
--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -62,18 +62,18 @@ class SubmitterLocal(Submitter):
             if self.debug:
                 print(script)
                 runner = self.initialized_runner(script)
-                print("\n\n")
-                print(f"{' PARAMETERS ':#^80}")
+                # print all parameters
+                print("\n\n" + f"{' PARAMETERS ':#^80}")
                 print(runner.model.parameters)
-                print("\n\n")
-                print(f"{' NOMINAL EXPECTATION VALUES ':#^80}")
+                # print all expectation values
+                print("\n\n" + f"{' NOMINAL EXPECTATION VALUES ':#^80}")
                 try:
                     expectation_values = runner.model.nominal_expectation_values
                     max_key_length = max([len(k) for k in expectation_values.keys()])
                     for k, v in expectation_values.items():
                         print(f"{k:<{max_key_length}}   {v}")
-                except NotImplementedError:
-                    print("Not implemented")
+                except NotImplementedError as msg:
+                    warnings.warn(str(msg))
                 return runner
             subprocess.call(shlex.split(script))
 

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -61,7 +61,20 @@ class SubmitterLocal(Submitter):
         for _, (script, _) in enumerate(self.combined_tickets_generator()):
             if self.debug:
                 print(script)
-                return self.initialized_runner(script)
+                runner = self.initialized_runner(script)
+                print("\n\n")
+                print(f"{' PARAMETERS ':#^80}")
+                print(runner.model.parameters)
+                print("\n\n")
+                print(f"{' NOMINAL EXPECTATION VALUES ':#^80}")
+                try:
+                    expectation_values = runner.model.nominal_expectation_values
+                    max_key_length = max([len(k) for k in expectation_values.keys()])
+                    for k, v in expectation_values.items():
+                        print(f"{k:<{max_key_length}}   {v}")
+                except NotImplementedError:
+                    print("Not implemented")
+                return runner
             subprocess.call(shlex.split(script))
 
 


### PR DESCRIPTION
This small PR simply adds some useful information output when submitting with `--local --debug`.
In particular, it will print the parameter overview table and if available the nominal expectation values.