### PR TITLE
Estimator of signal multiplier based on perturbation theory

### DIFF
--- a/alea/utils.py
+++ b/alea/utils.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 from typing import Any, List, Dict, Tuple, Optional, Union, cast, get_args, get_origin
 
 import h5py
+import matplotlib.pyplot as plt
 
 # These imports are needed to evaluate strings
 import numpy  # noqa: F401
@@ -611,7 +612,11 @@ def deterministic_hash(thing, length=10):
 
 
 def signal_multiplier_estimator(
-    signal: np.ndarray, background: np.ndarray, data: np.ndarray, iteration=100
+    signal: np.ndarray,
+    background: np.ndarray,
+    data: np.ndarray,
+    iteration=100,
+    diagnostic=False,
 ) -> float:
     """Estimate the best-fit signal multiplier using perturbation theory. The method tries to solve
     the critial point of the likelihood function by perturbation theory, where the likelihood
@@ -646,7 +651,13 @@ def signal_multiplier_estimator(
     # in which case the perturbation theory may not converge or be negative.
     # Thus we clip it to be non-negative.
     x = np.sum(obs - bkg) / np.sum(sig)
+    xs = [x]
     for _ in range(iteration):
         x += correction_on_multiplier(x)
         x = np.clip(x, 0, None)
+        xs.append(x)
+    if diagnostic:
+        plt.plot(xs, marker=".")
+        plt.xlabel("Iteration")
+        plt.ylabel("x")
     return x

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -613,6 +613,20 @@ def deterministic_hash(thing, length=10):
 def signal_multiplier_estimation(
     signal: np.ndarray, background: np.ndarray, data: np.ndarray, iteration=100
 ) -> float:
+    """Estimate the best-fit signal multiplier using perturbation theory. The method tries to solve
+    the critial point of the likelihood function by perturbation theory, where the likelihood
+    function is defined as the binned Poisson likelihood function, given signal, background models
+    and data.
+
+    Args:
+        signal (np.ndarray): signal model
+        background (np.ndarray): background model
+        data (np.ndarray): data array
+        iteration (int, optional (default=100)): number of iterations
+    Returns:
+        float: best-fit signal multiplier
+
+    """
     mask = (signal > 0) | (background > 0)
     if np.any(data[~mask] > 0):
         raise ValueError("Data has non-zero values where signal and background is zero.")
@@ -631,4 +645,8 @@ def signal_multiplier_estimation(
     for _ in range(iteration):
         x.append(x[-1] + correction_on_multiplier(x[-1]))
 
+    # For underfluctutation case, the best-fit multiplier could be negative
+    # in which case the perturbation theory may not converge or be negative.
+    # Thus we average the last 10 values to get a stable result and clip it
+    # to be non-negative.
     return np.clip(np.mean(x[-10:]), 0, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,4 +112,4 @@ class TestUtils(TestCase):
         )
         data = (bkg + sig * 1e-1).get_random(size=np.random.poisson(bkg.n))
         data = mh.Histdd(*data.T, bins=bkg.bin_edges)
-        signal_multiplier_estimator(sig.histogram, bkg.histogram, data.histogram)
+        signal_multiplier_estimator(sig.histogram, bkg.histogram, data.histogram, diagnostic=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
 import numpy as np
+import inference_interface as ii
+import multihist as mh
 from scipy.stats import chi2
 
 from alea.utils import (
@@ -14,6 +16,8 @@ from alea.utils import (
     expand_grid_dict,
     convert_to_vary,
     deterministic_hash,
+    get_file_path,
+    signal_multiplier_estimator,
 )
 
 
@@ -98,3 +102,14 @@ class TestUtils(TestCase):
         self.assertEqual(
             deterministic_hash({"a": np.array([0, 1]), "b": np.array([0, 1])}), "anxefavaju"
         )
+
+    def test_signal_multiplier_estimator(self):
+        bkg = ii.template_to_multihist(
+            get_file_path("er_template_0.ii.h5"), hist_name="er_template"
+        )
+        sig = ii.template_to_multihist(
+            get_file_path("wimp50gev_template.ii.h5"), hist_name="wimp_template"
+        )
+        data = (bkg + sig * 1e-1).get_random(size=np.random.poisson(bkg.n))
+        data = mh.Histdd(*data.T, bins=bkg.bin_edges)
+        signal_multiplier_estimator(sig.histogram, bkg.histogram, data.histogram)


### PR DESCRIPTION
This PR adds a function to alea.utils that can estimate the best-fit signal multiplier given signal background model and data histogram. Compared to the iminuit fitting, it totally gets rid of the initial guess, which could cause fitting failure if it's too ridiculous. This function can be used as an initial guess of the multiplier when there are more nuisance parameters in the likelihood. The math is summarized [here](https://xe1t-wiki.lngs.infn.it/lib/exe/fetch.php?media=xenon:xenonnt:zihao:alea:signal_multiplier_estimator.pdf)

When testing it, it already gives quite good fit

![Screenshot 2024-03-17 at 1 44 34 PM](https://github.com/XENONnT/alea/assets/39773361/7fe9263c-a424-415a-9d0a-24af39666c52)

To reproduce it,
```
import numpy as np
import multihist as mh
import matplotlib.pyplot as plt
import inference_interface as ii

from alea.utils import signal_multiplier_estimator

np.random.seed(1)

@np.errstate(invalid='ignore', divide='ignore')
def loglikelihood(lam, data, bkg, sig):
    exp = bkg + lam * sig
    assert np.all(data[exp <= 0] == 0)
    return np.sum(np.where(exp > 0, data * np.log(exp) - exp, 0))

bkg = ii.template_to_multihist('/home/zihaoxu/alea/alea/examples/templates/er_template_0.ii.h5', hist_name='er_template')
sig = ii.template_to_multihist('/home/zihaoxu/alea/alea/examples/templates/wimp50gev_template.ii.h5', hist_name='wimp_template')

data = (bkg + sig*1e-1).get_random(size=np.random.poisson(bkg.n))
data = mh.Histdd(*data.T, bins=bkg.bin_edges)

x = np.logspace(-3, 0.3, 100)
plt.plot(x, [loglikelihood(_x, data.histogram, bkg.histogram, sig.histogram) for _x in x])
best_fit_x = signal_multiplier_estimator(sig.histogram, bkg.histogram, data.histogram)
plt.axvline(best_fit_x, color='r', ls='--')
plt.title(f'Best fit multiplier = {best_fit_x:.1e}')
plt.xscale('log')
plt.ylabel('log likelihood')
plt.xlabel('WIMP multiplier')
plt.show()
```