### PR TITLE
Consistent sorting for BlueiceExtendedModel

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -202,6 +202,8 @@ class BlueiceExtendedModel(StatisticalModel):
             mus = self.data_generators[ll_index].mus
             for n, mu in zip(self.likelihood_list[ll_index].source_name_list, mus):
                 ret[ll_name][n] = mu
+            # sort by source name
+            ret[ll_name] = dict(sorted(ret[ll_name].items(), key=lambda item: item[0]))
         if not per_likelihood_term:
             # sum over sources with same names of all likelihood terms
             ret = {
@@ -253,6 +255,9 @@ class BlueiceExtendedModel(StatisticalModel):
         elif not expected_events and not self.data_generators[ll_index].binned:
             for hist in source_histograms.values():
                 hist.histogram /= hist.bin_volumes()
+
+        # sort the source_histograms by source name
+        source_histograms = dict(sorted(source_histograms.items(), key=lambda item: item[0]))
 
         return source_histograms
 

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -239,3 +239,19 @@ class TestBlueiceExtendedModel(TestCase):
             # check that invalid likelihood names fail
             with self.assertRaises(ValueError):
                 model.get_source_histograms("alea_iacta_est")
+
+    def test_sorted_returns(self):
+        """Test if sources are sorted in the same way for all return dicts."""
+        for model in self.models:
+            mus_per_ll = model.get_expectation_values(per_likelihood_term=True)
+            mus = model.get_expectation_values()
+            hist_per_ll = {}
+            for ll_name in model.likelihood_names[:-1]:
+                hist_per_ll[ll_name] = model.get_source_histograms(ll_name)
+            # check that keys are the same for each SR
+            for ll_name in model.likelihood_names[:-1]:
+                self.assertEqual(mus_per_ll[ll_name].keys(), hist_per_ll[ll_name].keys())
+            # check that global keys are the same
+            all_keys = {v for d in mus_per_ll.values() for v in d.keys()}
+            all_keys = sorted(all_keys)
+            self.assertEqual(all_keys, sorted(mus.keys()))


### PR DESCRIPTION
@dachengx noticed that there is an inconsistency between the sorting when using `get_expectation_values()` and `get_source_histograms(...)`. This is not critical since only dictionaries are returned but can lead to confusion when looping through items.

This PR fixes this issue and sorts all returns by the source name.