### PR TITLE
Fixed data storing

### DIFF
--- a/alea/model.py
+++ b/alea/model.py
@@ -11,7 +11,7 @@ from blueice.likelihood import _needs_data
 from inference_interface import toydata_to_file
 
 from alea.parameters import Parameters
-from alea.utils import within_limits, clip_limits, asymptotic_critical_value
+from alea.utils import within_limits, clip_limits, asymptotic_critical_value, ReadOnlyDict
 
 
 class StatisticalModel:
@@ -217,7 +217,9 @@ class StatisticalModel:
             metadata (dict, optional (default=None)): metadata to store with the data.
                 If None, no metadata is stored.
         """
-        if all([isinstance(d, dict) for d in data_list]):
+        if all([isinstance(d, dict) for d in data_list]) or all(
+            [isinstance(d, ReadOnlyDict) for d in data_list]
+        ):
             _data_list = [list(d.values()) for d in data_list]
         elif all([isinstance(d, list) for d in data_list]):
             _data_list = data_list

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -57,6 +57,15 @@ class ReadOnlyDict:
             "This dictionary is read-only, please initialize a new one in order to change it."
         )
 
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def items(self):
+        return self._data.items()
+
 
 def evaluate_numpy_scipy_expression(value: str):
     """Evaluate numpy(np) and scipy.stats expression."""

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -124,12 +124,22 @@ class TestBlueiceExtendedModel(TestCase):
             for key, summed_val in summed_vals.items():
                 self.assertEqual(summed_val, vals_total[key])
 
+    def test_store_data(self):
+        """Test of the generate_data method."""
+        for model, n in zip(self.models, self.n_likelihood_terms):
+            data = model.generate_data()
+            model.data = data
+            data_list_of_dict = [data]
+            data_list_of_ordereddict = [model.data]
+            data_list_of_list = [[data[k] for k in data.keys()]]
+            for d in [data_list_of_dict, data_list_of_ordereddict, data_list_of_list]:
+                model.store_data(self.toydata_filename, d)
+                remove(self.toydata_filename)
+
     def test_generate_data(self):
         """Test of the generate_data method."""
         for model, n in zip(self.models, self.n_likelihood_terms):
             data = model.generate_data()
-            model.store_data(self.toydata_filename, [data])
-            remove(self.toydata_filename)
             self.assertEqual(len(data), n + 2)
             if not (("ancillary" in data) and ("generate_values" in data)):
                 raise ValueError("Data does not contain ancillary and generate_values.")


### PR DESCRIPTION
If toy data is already assigned to the model, it will be converted to `alea.utils.ReadOnlyDict`. So far, this type was not supported by the builtin `model.store_data()` method, which is changed with this PR.

Now you can:

```python
model = ...
model.data = model.generate_data()
model.store_data(file_name, [model.data])
```