### PR TITLE
Fitting index variables

### DIFF
--- a/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
@@ -34,7 +34,7 @@ parameter_definition:
 
   er_band_shift:
     nominal_value: 0
-    ptype: shape_index
+    ptype: index
     uncertainty: null
     fittable: true
     blueice_anchors:

--- a/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
@@ -54,6 +54,7 @@ likelihood_config:
     - name: science_run
       default_source_class: alea.template_source.TemplateSource
       likelihood_type: blueice.likelihood.UnbinnedLogLikelihood
+      likelihood_config: {"morpher": "IndexMorpher"}
       analysis_space:
         - cs1: np.arange(0, 102, 2)
         - cs2: np.geomspace(100, 100000, 51)

--- a/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
@@ -1,0 +1,78 @@
+parameter_definition:
+  wimp_mass:
+    nominal_value: 50
+    fittable: false
+    description: WIMP mass in GeV/c^2
+
+  livetime:
+    nominal_value: 2.
+    ptype: livetime
+    fittable: false
+    description: Livetime in years
+
+  wimp_rate_multiplier:
+    nominal_value: 1.0
+    ptype: rate
+    fittable: true
+    fit_limits:
+      - 0
+      - null
+    parameter_interval_bounds:
+      - 0
+      - 50
+
+  er_rate_multiplier:
+    nominal_value: 1.0
+    ptype: rate
+    uncertainty: 0.2
+    relative_uncertainty: true
+    fittable: true
+    fit_limits:
+      - 0
+      - null
+    fit_guess: 1.0
+
+  er_band_shift:
+    nominal_value: 0
+    ptype: shape_index
+    uncertainty: null
+    fittable: true
+    blueice_anchors:
+      - -2
+      - -1
+      - 0
+      - 1
+      - 2
+    fit_limits:
+      - -2
+      - 2
+    description: ER band shape parameter (shifts the ER band up and down)
+
+likelihood_config:
+  template_folder: null  # will try to find the templates in alea
+  likelihood_terms:
+    - name: science_run
+      default_source_class: alea.template_source.TemplateSource
+      likelihood_type: blueice.likelihood.UnbinnedLogLikelihood
+      analysis_space:
+        - cs1: np.arange(0, 102, 2)
+        - cs2: np.geomspace(100, 100000, 51)
+      in_events_per_bin: true
+      livetime_parameter: livetime
+      slice_args: {}
+      sources:
+      - name: er
+        histname: er_template
+        parameters:
+          - er_rate_multiplier
+          - er_band_shift
+        named_parameters:
+          - er_band_shift
+        template_filename: er_template_{er_band_shift}.ii.h5
+
+      - name: wimp
+        histname: wimp_template
+        parameters:
+          - wimp_rate_multiplier
+          - wimp_mass
+        template_filename: wimp50gev_template.ii.h5

--- a/alea/model.py
+++ b/alea/model.py
@@ -344,7 +344,7 @@ class StatisticalModel:
         index_variables = [
             p
             for p in self.parameters.parameters.values()
-            if "index" in p.ptype and p.name not in fixed_params
+            if "index" in str(p.ptype) and p.name not in fixed_params
         ]
 
         if (not index_fitting) or (len(index_variables) == 0):

--- a/alea/model.py
+++ b/alea/model.py
@@ -391,7 +391,8 @@ class StatisticalModel:
             for var in index_names:
                 m.values[var] = index_grid[np.argmax(lls)][var]
 
-            # Calculating Hessian will update the validity of the fitting given the new index variables
+            # Calculating Hessian will update the validity of
+            # the fitting given the new index variables
             m.hesse()
             if m.valid:
                 break

--- a/alea/model.py
+++ b/alea/model.py
@@ -349,51 +349,59 @@ class StatisticalModel:
 
         if (not index_fitting) or (len(index_variables) == 0):
             # Call migrad to do the actual minimization
-            m.migrad()
+            m = self._migrad_fit(m)
         else:
-            index_anchors = [var.blueice_anchors for var in index_variables]
-            index_names = [var.name for var in index_variables]
-            index_grid = [
-                {index_names[i]: anchor[i] for i in range(len(anchor))}
-                for anchor in product(*index_anchors)
-            ]
-
-            # We fix the index variables in migrad
-            for par in index_names:
-                m.fixed[par] = True
-
-            # We firstly do optimization on other parameters with index variables
-            # fixed to their initial guesses. Then we grid search over the index
-            # variables given the optimized parameters. We repeat the optimization
-            # and grid search until the optimization converges
-            for itr in range(max_index_fitting_iter):
-                m.migrad()
-
-                # Find the best-fit index variables
-                lls = np.zeros(len(index_grid))
-                for i in range(len(lls)):
-                    params = m.values.to_dict()
-                    params.update(index_grid[i])
-                    lls[i] = self.ll(**params)
-                for var in index_names:
-                    m.values[var] = index_grid[np.argmax(lls)][var]
-
-                # Calculating Hessian will update the validity of the fitting given the new index variables
-                m.hesse()
-                if m.valid:
-                    break
-
-            if verbose and itr == max_index_fitting_iter - 1:
-                print(
-                    "The index searching iteration times reached the maximum! "
-                    "The optimization could not converge!"
-                )
+            m = self._migrad_index_mixing_fit(m, index_variables, max_index_fitting_iter, verbose)
 
         self.minuit_object = m
         if verbose:
             print(m)
         # alert! This gives the _maximum_ likelihood
         return m.values.to_dict(), -1 * m.fval
+
+    def _migrad_fit(self, m):
+        m.migrad()
+        return m
+
+    def _migrad_index_mixing_fit(self, m, index_variables, max_index_fitting_iter, verbose):
+        index_anchors = [var.blueice_anchors for var in index_variables]
+        index_names = [var.name for var in index_variables]
+        index_grid = [
+            {index_names[i]: anchor[i] for i in range(len(anchor))}
+            for anchor in product(*index_anchors)
+        ]
+
+        # We fix the index variables in migrad
+        for par in index_names:
+            m.fixed[par] = True
+
+        # We firstly do optimization on other parameters with index variables
+        # fixed to their initial guesses. Then we grid search over the index
+        # variables given the optimized parameters. We repeat the optimization
+        # and grid search until the optimization converges
+        for itr in range(max_index_fitting_iter):
+            m.migrad()
+
+            # Find the best-fit index variables
+            lls = np.zeros(len(index_grid))
+            for i in range(len(lls)):
+                params = m.values.to_dict()
+                params.update(index_grid[i])
+                lls[i] = self.ll(**params)
+            for var in index_names:
+                m.values[var] = index_grid[np.argmax(lls)][var]
+
+            # Calculating Hessian will update the validity of the fitting given the new index variables
+            m.hesse()
+            if m.valid:
+                break
+
+        if verbose and itr == max_index_fitting_iter - 1:
+            print(
+                "The index searching iteration times reached the maximum! "
+                "The optimization could not converge!"
+            )
+        return m
 
     def _confidence_interval_checks(
         self,

--- a/alea/model.py
+++ b/alea/model.py
@@ -344,7 +344,7 @@ class StatisticalModel:
         index_variables = [
             p
             for p in self.parameters.parameters.values()
-            if "index" in str(p.ptype) and p.name not in fixed_params
+            if p.ptype == "index" and p.name not in fixed_params
         ]
 
         if (not index_fitting) or (len(index_variables) == 0):

--- a/alea/model.py
+++ b/alea/model.py
@@ -307,7 +307,9 @@ class StatisticalModel:
         return cost
 
     @_needs_data
-    def fit(self, verbose=False, index_fitting=True, max_index_fitting_iter=10, **kwargs) -> Tuple[dict, float]:
+    def fit(
+        self, verbose=False, index_fitting=True, max_index_fitting_iter=10, **kwargs
+    ) -> Tuple[dict, float]:
         """Fit the model to the data by maximizing the likelihood. Return a dict containing best-fit
         values of each parameter, and the value of the likelihood evaluated there. While the
         optimization is a minimization, the likelihood returned is the __maximum__ of the
@@ -339,7 +341,11 @@ class StatisticalModel:
             m.fixed[par] = True
 
         # Get the index variables, which could have problem if simply using migrad
-        index_variables = [p for p in self.parameters.parameters.values() if "index" in p.ptype and p.name not in fixed_params]
+        index_variables = [
+            p
+            for p in self.parameters.parameters.values()
+            if "index" in p.ptype and p.name not in fixed_params
+        ]
 
         if (not index_fitting) or (len(index_variables) == 0):
             # Call migrad to do the actual minimization
@@ -347,7 +353,10 @@ class StatisticalModel:
         else:
             index_anchors = [var.blueice_anchors for var in index_variables]
             index_names = [var.name for var in index_variables]
-            index_grid = [{index_names[i]: anchor[i] for i in range(len(anchor))} for anchor in product(*index_anchors)]
+            index_grid = [
+                {index_names[i]: anchor[i] for i in range(len(anchor))}
+                for anchor in product(*index_anchors)
+            ]
 
             # We fix the index variables in migrad
             for par in index_names:
@@ -375,8 +384,10 @@ class StatisticalModel:
                     break
 
             if verbose and itr == max_index_fitting_iter - 1:
-                print("The index searching iteration times reached the maximum! "
-                      "The optimization could not converge!")
+                print(
+                    "The index searching iteration times reached the maximum! "
+                    "The optimization could not converge!"
+                )
 
         self.minuit_object = m
         if verbose:

--- a/alea/model.py
+++ b/alea/model.py
@@ -3,6 +3,7 @@ import warnings
 from pydoc import locate
 from copy import deepcopy
 from typing import List, Tuple, Callable, Optional, Union
+from itertools import product
 
 import numpy as np
 from scipy.optimize import brentq
@@ -306,7 +307,7 @@ class StatisticalModel:
         return cost
 
     @_needs_data
-    def fit(self, verbose=False, **kwargs) -> Tuple[dict, float]:
+    def fit(self, verbose=False, index_fitting=True, max_index_fitting_iter=10, **kwargs) -> Tuple[dict, float]:
         """Fit the model to the data by maximizing the likelihood. Return a dict containing best-fit
         values of each parameter, and the value of the likelihood evaluated there. While the
         optimization is a minimization, the likelihood returned is the __maximum__ of the
@@ -337,8 +338,46 @@ class StatisticalModel:
         for par in fixed_params:
             m.fixed[par] = True
 
-        # Call migrad to do the actual minimization
-        m.migrad()
+        # Get the index variables, which could have problem if simply using migrad
+        index_variables = [p for p in self.parameters.parameters.values() if "index" in p.ptype and p.name not in fixed_params]
+
+        if (not index_fitting) or (len(index_variables) == 0):
+            # Call migrad to do the actual minimization
+            m.migrad()
+        else:
+            index_anchors = [var.blueice_anchors for var in index_variables]
+            index_names = [var.name for var in index_variables]
+            index_grid = [{index_names[i]: anchor[i] for i in range(len(anchor))} for anchor in product(*index_anchors)]
+
+            # We fix the index variables in migrad
+            for par in index_names:
+                m.fixed[par] = True
+
+            # We firstly do optimization on other parameters with index variables
+            # fixed to their initial guesses. Then we grid search over the index
+            # variables given the optimized parameters. We repeat the optimization
+            # and grid search until the optimization converges
+            for itr in range(max_index_fitting_iter):
+                m.migrad()
+
+                # Find the best-fit index variables
+                lls = np.zeros(len(index_grid))
+                for i in range(len(lls)):
+                    params = m.values.to_dict()
+                    params.update(index_grid[i])
+                    lls[i] = self.ll(**params)
+                for var in index_names:
+                    m.values[var] = index_grid[np.argmax(lls)][var]
+
+                # Calculating Hessian will update the validity of the fitting given the new index variables
+                m.hesse()
+                if m.valid:
+                    break
+
+            if verbose and itr == max_index_fitting_iter - 1:
+                print("The index searching iteration times reached the maximum! "
+                      "The optimization could not converge!")
+
         self.minuit_object = m
         if verbose:
             print(m)

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -305,12 +305,7 @@ class BlueiceExtendedModel(StatisticalModel):
         parameters_to_ignore: List[str] = [
             p.name
             for p in self.parameters
-            if (p.ptype == "shape") and (p.name not in source["parameters"])
-        ]
-        parameters_to_ignore += [
-            p.name
-            for p in self.parameters
-            if (p.ptype == "index") and (p.name not in source["parameters"])
+            if (p.ptype in ["shape", "index"]) and (p.name not in source["parameters"])
         ]
         # no efficiency affects PDF:
         parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
@@ -372,8 +367,7 @@ class BlueiceExtendedModel(StatisticalModel):
                 shape_parameters = [
                     p
                     for p in source["parameters"]
-                    if (self.parameters[p].ptype == "shape")
-                    or (self.parameters[p].ptype == "index")
+                    if self.parameters[p].ptype in ["shape", "index"]
                 ]
                 for p in shape_parameters:
                     anchors = self.parameters[p].blueice_anchors
@@ -532,7 +526,7 @@ class BlueiceExtendedModel(StatisticalModel):
         If no ptype is specified, set the default ptype "needs_reinit".
 
         """
-        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit", "index"]
+        allowed_ptypes = ["rate", "shape", "index", "efficiency", "livetime", "needs_reinit"]
         default_ptype = "needs_reinit"
         for p in self.parameters:
             if p.ptype is None:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -292,7 +292,11 @@ class BlueiceExtendedModel(StatisticalModel):
                 for p in self.parameters
                 if (p.ptype == "shape") and (p.name not in source["parameters"])
             ]
-            parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "index") and (p.name not in source["parameters"])]
+            parameters_to_ignore += [
+                p.name
+                for p in self.parameters
+                if (p.ptype == "shape_index") and (p.name not in source["parameters"])
+            ]
             # no efficiency affects PDF:
             parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
             parameters_to_ignore += source.get("extra_dont_hash_settings", [])
@@ -355,7 +359,7 @@ class BlueiceExtendedModel(StatisticalModel):
 
                 # set shape parameters
                 shape_parameters = [
-                    p for p in source["parameters"] if self.parameters[p].ptype == "shape"
+                    p for p in source["parameters"] if (self.parameters[p].ptype == "shape") or (self.parameters[p].ptype == "shape_index")
                 ]
                 for p in shape_parameters:
                     anchors = self.parameters[p].blueice_anchors
@@ -514,7 +518,7 @@ class BlueiceExtendedModel(StatisticalModel):
         If no ptype is specified, set the default ptype "needs_reinit".
 
         """
-        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit", "index"]
+        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit", "shape_index"]
         default_ptype = "needs_reinit"
         for p in self.parameters:
             if p.ptype is None:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -287,24 +287,27 @@ class BlueiceExtendedModel(StatisticalModel):
 
         # add all parameters to extra_dont_hash for each source unless it is used:
         for i, source in enumerate(config["sources"]):
-            parameters_to_ignore: List[str] = [
-                p.name
-                for p in self.parameters
-                if (p.ptype == "shape") and (p.name not in source["parameters"])
-            ]
-            parameters_to_ignore += [
-                p.name
-                for p in self.parameters
-                if (p.ptype == "shape_index") and (p.name not in source["parameters"])
-            ]
-            # no efficiency affects PDF:
-            parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
-            parameters_to_ignore += source.get("extra_dont_hash_settings", [])
-
+            parameters_to_ignore = self._get_parameters_to_ignore(source)
             # ignore all shape parameters known to this model not named specifically
             # in the source:
             blueice_config["sources"][i]["extra_dont_hash_settings"] = parameters_to_ignore
         return blueice_config
+
+    def _get_parameters_to_ignore(self, source):
+        parameters_to_ignore: List[str] = [
+            p.name
+            for p in self.parameters
+            if (p.ptype == "shape") and (p.name not in source["parameters"])
+        ]
+        parameters_to_ignore += [
+            p.name
+            for p in self.parameters
+            if (p.ptype == "shape_index") and (p.name not in source["parameters"])
+        ]
+        # no efficiency affects PDF:
+        parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
+        parameters_to_ignore += source.get("extra_dont_hash_settings", [])
+        return parameters_to_ignore
 
     def _build_ll_from_config(
         self, likelihood_config: dict, template_path: Optional[str] = None

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -310,7 +310,7 @@ class BlueiceExtendedModel(StatisticalModel):
         parameters_to_ignore += [
             p.name
             for p in self.parameters
-            if (p.ptype == "shape_index") and (p.name not in source["parameters"])
+            if (p.ptype == "index") and (p.name not in source["parameters"])
         ]
         # no efficiency affects PDF:
         parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
@@ -373,7 +373,7 @@ class BlueiceExtendedModel(StatisticalModel):
                     p
                     for p in source["parameters"]
                     if (self.parameters[p].ptype == "shape")
-                    or (self.parameters[p].ptype == "shape_index")
+                    or (self.parameters[p].ptype == "index")
                 ]
                 for p in shape_parameters:
                     anchors = self.parameters[p].blueice_anchors
@@ -532,7 +532,7 @@ class BlueiceExtendedModel(StatisticalModel):
         If no ptype is specified, set the default ptype "needs_reinit".
 
         """
-        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit", "shape_index"]
+        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit", "index"]
         default_ptype = "needs_reinit"
         for p in self.parameters:
             if p.ptype is None:

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -359,7 +359,10 @@ class BlueiceExtendedModel(StatisticalModel):
 
                 # set shape parameters
                 shape_parameters = [
-                    p for p in source["parameters"] if (self.parameters[p].ptype == "shape") or (self.parameters[p].ptype == "shape_index")
+                    p
+                    for p in source["parameters"]
+                    if (self.parameters[p].ptype == "shape")
+                    or (self.parameters[p].ptype == "shape_index")
                 ]
                 for p in shape_parameters:
                     anchors = self.parameters[p].blueice_anchors

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -292,6 +292,7 @@ class BlueiceExtendedModel(StatisticalModel):
                 for p in self.parameters
                 if (p.ptype == "shape") and (p.name not in source["parameters"])
             ]
+            parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "index") and (p.name not in source["parameters"])]
             # no efficiency affects PDF:
             parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]
             parameters_to_ignore += source.get("extra_dont_hash_settings", [])
@@ -513,7 +514,7 @@ class BlueiceExtendedModel(StatisticalModel):
         If no ptype is specified, set the default ptype "needs_reinit".
 
         """
-        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit"]
+        allowed_ptypes = ["rate", "shape", "efficiency", "livetime", "needs_reinit", "index"]
         default_ptype = "needs_reinit"
         for p in self.parameters:
             if p.ptype is None:

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -4,6 +4,7 @@ import json
 import yaml
 import importlib_resources
 import itertools
+import blueice
 from glob import glob
 from copy import deepcopy
 from pydoc import locate
@@ -12,6 +13,8 @@ from hashlib import sha256
 from base64 import b32encode
 from collections.abc import Mapping
 from typing import Any, List, Dict, Tuple, Optional, Union, cast, get_args, get_origin
+from blueice.pdf_morphers import Morpher
+from itertools import product
 
 import h5py
 import matplotlib.pyplot as plt
@@ -670,3 +673,15 @@ def signal_multiplier_estimator(
         plt.xlabel("Iteration")
         plt.ylabel("x")
     return x
+
+
+class IndexMorpher(Morpher):
+    """IndexMorpher is a morpher which applies no interpolation."""
+    def get_anchor_points(self, bounds, n_models=None):
+        grid = [par.keys() for _, (par, _, _) in self.shape_parameters.items()]
+        return list(product(*grid))
+
+    def make_interpolator(self, f, extra_dims, anchor_models):
+        return lambda z: f(anchor_models[tuple(z)])
+
+blueice.pdf_morphers.MORPHERS["IndexMorpher"] = IndexMorpher

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -677,11 +677,13 @@ def signal_multiplier_estimator(
 
 class IndexMorpher(Morpher):
     """IndexMorpher is a morpher which applies no interpolation."""
+
     def get_anchor_points(self, bounds, n_models=None):
         grid = [par.keys() for _, (par, _, _) in self.shape_parameters.items()]
         return list(product(*grid))
 
     def make_interpolator(self, f, extra_dims, anchor_models):
         return lambda z: f(anchor_models[tuple(z)])
+
 
 blueice.pdf_morphers.MORPHERS["IndexMorpher"] = IndexMorpher

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -195,33 +195,6 @@ class TestBlueiceExtendedModel(TestCase):
             for p in model.parameters:
                 self.assertEqual(p.nominal_value, fit_result_fixed[p.name])
 
-    def test_index_fit(self):
-        """Test of the index_fit method."""
-        for model in self.models:
-            model.data = model.generate_data()
-            index = np.random.randint(0, len(model.data["source"]))
-            fit_result, max_llh = model.index_fit(index)
-
-            # check whether all parameters are in fit_result
-            self.assertEqual(set(model.parameters.names), set(fit_result.keys()))
-
-            # check that non-fittable parameters are not fitted
-            for p in model.parameters:
-                if not p.fittable:
-                    self.assertEqual(p.nominal_value, fit_result[p.name])
-
-            # check that values are in fit limits
-            for p in model.parameters:
-                p.value_in_fit_limits(fit_result[p.name])
-
-            # check that likelihood is maximized
-            self.assertEqual(max_llh, model.ll(**fit_result))
-
-            # check that fixing all parameters to nominal works
-            fit_result_fixed, _ = model.index_fit(index, **model.parameters())
-            for p in model.parameters:
-                self.assertEqual(p.nominal_value, fit_result_fixed[p.name])
-
     def test_store_real_data(self):
         """Test of the store_real_data method."""
         for model, n in zip(self.models, self.n_likelihood_terms):


### PR DESCRIPTION
This PR modifies the default model.fit to support mixing continuous variables and index variables, with **little** extra time consuming. In this PR I only considered index variables as the shape parameter, i.e. a new ptype called `shape_index`. But the function can be easily used whenever we need other index variables in the future.

I did this because shape parameter usually causes many fitting problems since the likelihood can hardly be convex within the fitting limit if the shape parameter is not defined in a very careful way. Thus an alternative method is to do grid search on anchors as well as the `migrad()`. However if you simply do `migrad()` on all anchor points the computation speed will be significantly lowered. In this PR I do it in this way:

  - Fix index variables to their guesses, fit other normal parameters.
  - Fix other normal parameters to the best fit in last step, grid search index variables and find the best fit index.
  - Iterate the above two steps for some times until converge.

In most of the cases we care about, this iteration usually just need to be done once to reach convergence.


Here is an example JIC you wanna have a quick test,
```
import numpy as np
import matplotlib.pyplot as plt
from alea import BlueiceExtendedModel

np.random.seed(1)

config = "unbinned_wimp_statistical_model_index_fitting.yaml"
model = BlueiceExtendedModel.from_config(config)
model.data = model.generate_data()
model.fit()
m = model.minuit_object

er_band_shift = model.parameters.parameters['er_band_shift'].blueice_anchors
ll = [model.ll(er_band_shift=x) for x in er_band_shift]

plt.scatter(er_band_shift, ll)
plt.axvline(m.values['er_band_shift'], label='model.fit')
plt.legend()
plt.xticks(er_band_shift)
plt.xlabel('er_band_shift as index variable')
plt.ylabel('model.ll')
plt.show()
```
<img width="528" alt="Screenshot 2024-04-08 at 8 23 59 PM" src="https://github.com/XENONnT/alea/assets/39773361/de51b499-893a-4cf3-aaa4-fb95c2852653">

