### PR TITLE
Set `i_batch` for `SubmitterLocal` when submitting

### DIFF
--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -62,6 +62,7 @@ class Submitter:
     config_file_path: str
     template_path: str
     combine_n_jobs: int = 1
+    first_i_batch: int = 0
     allowed_special_args: List[str] = []
     logging = logging.getLogger("submitter_logger")
 
@@ -336,7 +337,7 @@ class Submitter:
         _, _, annotations = Runner.runner_arguments()
 
         for runner_args in self.merged_arguments_generator():
-            for i_batch in range(runner_args.get("n_batch", 1)):
+            for i_batch in range(self.first_i_batch, runner_args.get("n_batch", 1)):
                 i_args = deepcopy(runner_args)
                 i_args["i_batch"] = i_batch
 

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -33,6 +33,7 @@ class SubmitterLocal(Submitter):
         self.local_configurations = kwargs.get("local_configurations", {})
         self.template_path = self.local_configurations.pop("template_path", None)
         self.combine_n_jobs = self.local_configurations.pop("combine_n_jobs", 1)
+        self.first_i_batch = kwargs.pop("i_batch", 1)
         super().__init__(*args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
The you can initialize the runner for `i_batch` toyMC:

```
submitter = SubmitterLocal.from_config(
    config_path,
    computation='sensitivity',
    outputfolder=outputfolder,
    debug=True,
    resubmit=True,
    i_batch=i_batch,
)
runner = submitter.submit()
```

For the `toydata_filename` in https://github.com/XENONnT/alea/blob/41119c7c2ec8f8438f9789d9c93911130d9cf8a1/alea/examples/configs/unbinned_wimp_running.yaml#L54 will be `toyfile_wimp_mass_50_poi_expectation_0.00.ii_2.h5` when `i_batch` is assigned to be 2.