### PR TITLE
Forbid prexing every key when adapt_likelihood_config_for_blueice

### DIFF
--- a/alea/utils.py
+++ b/alea/utils.py
@@ -125,7 +125,8 @@ def _prefix_file_path(
     Args:
         config (dict): dictionary contains file path
         template_folder_list (list): list of possible base folders. Ordered by priority.
-        ignore_keys (list, optional (default=["name", "histname"])): keys to be ignored when prefixing
+        ignore_keys (list, optional (default=["name", "histname"])): 
+        keys to be ignored when prefixing
 
     """
     for key in config.keys():

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -118,7 +118,7 @@ def get_analysis_space(analysis_space: list) -> list:
 
 
 def _prefix_file_path(
-    config: dict, template_folder_list: list, ignore_keys: Optional[str] = ["name", "histname"]
+    config: dict, template_folder_list: list, ignore_keys: Optional[List[str]] = ["name", "histname"]
 ):
     """Prefix file path with template_folder_list whenever possible.
 

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -125,7 +125,7 @@ def _prefix_file_path(
     Args:
         config (dict): dictionary contains file path
         template_folder_list (list): list of possible base folders. Ordered by priority.
-        ignore_keys (list, optional (default=["name", "histname"])): 
+        ignore_keys (list, optional (default=["name", "histname"])):
         keys to be ignored when prefixing
 
     """

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -118,7 +118,7 @@ def get_analysis_space(analysis_space: list) -> list:
 
 
 def _prefix_file_path(
-        config: dict, template_folder_list: list, ignore_keys: Optional[str] = ["name", "histname"]
+    config: dict, template_folder_list: list, ignore_keys: Optional[str] = ["name", "histname"]
 ):
     """Prefix file path with template_folder_list whenever possible.
 

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -117,16 +117,19 @@ def get_analysis_space(analysis_space: list) -> list:
     return eval_analysis_space
 
 
-def _prefix_file_path(config: dict, template_folder_list: list):
+def _prefix_file_path(
+        config: dict, template_folder_list: list, ignore_keys: Optional[str] = ["name", "histname"]
+):
     """Prefix file path with template_folder_list whenever possible.
 
     Args:
         config (dict): dictionary contains file path
         template_folder_list (list): list of possible base folders. Ordered by priority.
+        ignore_keys (list, optional (default=["name", "histname"])): keys to be ignored when prefixing
 
     """
     for key in config.keys():
-        if isinstance(config[key], str):
+        if isinstance(config[key], str) and key not in ignore_keys:
             try:
                 config[key] = get_file_path(config[key], template_folder_list)
             except RuntimeError:

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -118,7 +118,7 @@ def get_analysis_space(analysis_space: list) -> list:
 
 
 def _prefix_file_path(
-    config: dict, template_folder_list: list, ignore_keys: Optional[List[str]] = ["name", "histname"]
+    config: dict, template_folder_list: list, ignore_keys: List[str] = ["name", "histname"]
 ):
     """Prefix file path with template_folder_list whenever possible.
 


### PR DESCRIPTION
This is likely a bug introduced in #169. The original implementation was trying to prefix every field, as long as it happens to be an existing file after prefixing. You can see one example that this will lead to a problem.

Let's say you have defined the following sources in your statistical model yaml file:
```
      - name: b8
        histname: template
        parameters:
          - b8_rate_multiplier
          - t_ly
          - t_qy
        named_parameters:
          - t_ly
          - t_qy
        template_filename: cevns/template_XENONnT_sr0_cevns_cevns_tly_{t_ly:.1f}_tqy_{t_qy:.1f}.h5

      - name: ac
        histname: template
        parameters:
          - ac_rate_multiplier
        template_filename: ac/template_XENONnT_sr0_ac_cevns.h5
```
in this example, with current alea it will complain a bug. In general, as long as your source name coincidence with a path name after prefixing, it will give an issue.
```
  File "/home/yuanlq/software/blueice/blueice/likelihood.py", line 365, in _kwargs_to_settings
    raise InvalidParameter("%s is not a known shape or rate parameter!" % k)
blueice.exceptions.InvalidParameter: ac_rate_multiplier is not a known shape or rate parameter!
```
The issue took place inside `adapt_likelihood_config_for_blueice`. Before prefixing [here](https://github.com/XENONnT/alea/blob/13e9e8d1d457cc2633d68811aa833a06fcedc0f8/alea/utils.py#L179), `source` looks like
```
{'name': 'ac', 'histname': 'template', 'parameters': ['ac_rate_multiplier'], 'template_filename': 'ac/template_XENONnT_sr0_ac_cevns.h5', 'templatename': '/project2/lgrandi/light_wimp/templates/ambe_ybe_combined/ac/template_XENONnT_sr0_ac_cevns.h5'}
``` 
After, it becomes:
```
{'name': '/project2/lgrandi/light_wimp/templates/ambe_ybe_combined/ac', 'histname': 'template', 'parameters': ['ac_rate_multiplier'], 'template_filename': '/project2/lgrandi/light_wimp/templates/ambe_ybe_combined/ac/template_XENONnT_sr0_ac_cevns.h5', 'templatename': '/project2/lgrandi/light_wimp/templates/ambe_ybe_combined/ac/template_XENONnT_sr0_ac_cevns.h5'}
```
You can see that now the source name makes no sense. 

In this patch solution, we try to avoid config keys that will in no way be interpreted as a path or filename, by making them into `ignore_keys`. 