### PR TITLE
Allow assigning kwargs in debug mode

### DIFF
--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -355,9 +355,8 @@ class Submitter:
                             )
 
                 script = Submitter.script_from_runner_kwargs(annotations, i_args)
-                script = (
-                    f"python3 {self.run_toymc} "
-                    + " ".join(map(shlex.quote, script.split(" ")))
+                script = f"python3 {self.run_toymc} " + " ".join(
+                    map(shlex.quote, script.split(" "))
                 )
 
                 if not self.already_done(i_args):

--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -354,16 +354,9 @@ class Submitter:
                                 f"{needed_kwargs}, please check the {name}."
                             )
 
-                script_array = []
-                for arg, annotation in annotations.items():
-                    script_array.append(f"--{arg}")
-                    script_array.append(self.arg_to_str(i_args[arg], annotation))
-                script = " ".join(script_array)
-
+                script = Submitter.script_from_runner_kwargs(annotations, i_args)
                 script = (
-                    "python3 "
-                    + self.run_toymc
-                    + " "
+                    f"python3 {self.run_toymc} "
                     + " ".join(map(shlex.quote, script.split(" ")))
                 )
 
@@ -578,3 +571,13 @@ class Submitter:
         for arg, value in parsed_args.__dict__.items():
             kwargs.update({arg: Submitter.str_to_arg(value, signatures.parameters[arg].annotation)})
         return kwargs
+
+    @staticmethod
+    def script_from_runner_kwargs(annotations, kwargs) -> str:
+        """Generate the submission script from the runner arguments."""
+        script_array = []
+        for arg, annotation in annotations.items():
+            script_array.append(f"--{arg}")
+            script_array.append(Submitter.arg_to_str(kwargs[arg], annotation))
+        script = " ".join(script_array)
+        return script

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -53,7 +53,7 @@ class SubmitterLocal(Submitter):
         runner = Runner(**kwargs)
         return runner
 
-    def submit(self):
+    def submit(self, **kwargs):
         """Run job in subprocess locally.
 
         If debug is True, only return the first instance of Runner.
@@ -61,7 +61,22 @@ class SubmitterLocal(Submitter):
         """
         for _, (script, _) in enumerate(self.combined_tickets_generator()):
             if self.debug:
-                print(script)
+                if kwargs:
+                    print(f"{' KWARGS ':#^80}")
+                    print(kwargs)
+                    _, _, annotations = Runner.runner_arguments()
+                    runner_kwargs = Submitter.runner_kwargs_from_script(shlex.split(script)[2:])
+                    runner_kwargs.update(kwargs)
+                    script = Submitter.script_from_runner_kwargs(annotations, runner_kwargs)
+                    script = (
+                        f"python3 {self.run_toymc} "
+                        + " ".join(map(shlex.quote, script.split(" ")))
+                    )
+                    print("\n\n" + f"{' SCRIPT ':#^80}")
+                    print(script)
+                else:
+                    print(f"{' SCRIPT ':#^80}")
+                    print(script)
                 runner = self.initialized_runner(script)
                 # print all parameters
                 print("\n\n" + f"{' PARAMETERS ':#^80}")
@@ -487,7 +502,7 @@ class NeymanConstructor(SubmitterLocal):
                 # interpolate the threshold from the existing threshold
                 if len(hashed_keys["generate_values"]) == 0:
                     warnings.warn(
-                        f"If hypothesis {hypothesis} does not container any values except "
+                        f"If hypothesis {hypothesis} does not contain any values except "
                         f"poi, the nominal values should be in limit_threshold, so that "
                         f"the threshold can be interpolated from the existing threshold."
                     )

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -53,7 +53,7 @@ class SubmitterLocal(Submitter):
         runner = Runner(**kwargs)
         return runner
 
-    def submit(self, **kwargs):
+    def submit(self, *args, **kwargs):
         """Run job in subprocess locally.
 
         If debug is True, only return the first instance of Runner.

--- a/alea/submitters/local.py
+++ b/alea/submitters/local.py
@@ -68,9 +68,8 @@ class SubmitterLocal(Submitter):
                     runner_kwargs = Submitter.runner_kwargs_from_script(shlex.split(script)[2:])
                     runner_kwargs.update(kwargs)
                     script = Submitter.script_from_runner_kwargs(annotations, runner_kwargs)
-                    script = (
-                        f"python3 {self.run_toymc} "
-                        + " ".join(map(shlex.quote, script.split(" ")))
+                    script = f"python3 {self.run_toymc} " + " ".join(
+                        map(shlex.quote, script.split(" "))
                     )
                     print("\n\n" + f"{' SCRIPT ':#^80}")
                     print(script)


### PR DESCRIPTION
For example, you might want to change the argument of runner on the fly, like:

```
submitter = SubmitterLocal.from_config(
    ALEA_RUNNER_CONFIG_CL_PATH,
    computation="sensitivity",
    outputfolder="/project2/lgrandi/xudc/b8_unblindinding",
    debug=True,
    resubmit=True,
)

runner_68 = submitter.submit(confidence_level=0.6826894921370859)
runner_90 = submitter.submit(confidence_level=0.9)
```

`runner_68` calculates CL for 68% coverage, while `runner_90` is for 90% coverage.