### PR TITLE
Allow `confidence_level` in filename

### DIFF
--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -313,6 +313,7 @@ class Submitter:
         """
         needed_kwargs = {
             "i_batch": runner_args["i_batch"],
+            "confidence_level": runner_args["confidence_level"],
             **runner_args["nominal_values"],
             **runner_args["generate_values"],
         }


### PR DESCRIPTION
We should allow scanning `confidence_level` in runner configuratio `.yaml` file:

```
  sensitivity:
    to_vary:
      {
        t_ly: "np.linspace(0, 6, 7)",
        confidence_level: [0.6827, 0.9],
      }
```

Before this PR, you might see error like:

```
  File "/home/xudc/alea/alea/submitter.py", line 352, in computation_tickets_generator
    raise KeyError(
KeyError: "Keys for /home/xudc/out_alea/out_alea_b8_rate_exposure_scan/toymc_sensi_cevns_b8_rate_livetime_{livetime_sr
0:.2f}_{livetime_sr1:.2f}_b8_rate_{b8_rate_multiplier:.2f}_confidence_level_{confidence_level:.2f}_{i_batch:d}.h5 are 
not in provided arguments {'i_batch': 0, 'livetime_sr0': 1.174398, 'livetime_sr1': 0.0, 'b8_rate_multiplier': 1.0}, pl
ease check the output_filename."
```