### PR TITLE
Conditional Parameters

### DIFF
--- a/alea/examples/configs/unbinned_wimp_statistical_model_mass_dependent_efficiency.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model_mass_dependent_efficiency.yaml
@@ -1,0 +1,144 @@
+parameter_definition:
+  wimp_mass:
+    nominal_value: 50
+    fittable: false
+    description: WIMP mass in GeV/c^2
+
+  livetime_sr0:
+    nominal_value: 0.2
+    ptype: livetime
+    fittable: false
+    description: Livetime of SR0 in years
+
+  livetime_sr1:
+    nominal_value: 1.0
+    ptype: livetime
+    fittable: false
+    description: Livetime of SR1 in years
+
+  wimp_rate_multiplier:
+    nominal_value: 1.0
+    ptype: rate
+    fittable: true
+    fit_limits:
+      - 0
+      - null
+    parameter_interval_bounds:
+      - 0
+      - null
+
+  er_rate_multiplier:
+    nominal_value: 1.0
+    ptype: rate
+    uncertainty: 0.2
+    relative_uncertainty: true
+    fittable: true
+    fit_limits:
+      - 0
+      - null
+    fit_guess: 1.0
+
+  signal_efficiency:
+    conditioning_parameter_name: wimp_mass
+    nominal_value: 1.0
+    ptype: efficiency
+    uncertainty:
+      5: 0.3
+      10: 0.2
+      50: 0.15
+      100: 0.1
+      500: 0.1
+    relative_uncertainty: true
+    fittable: true
+    fit_limits:
+      - 0
+      - 10.
+    fit_guess: 1.0
+    description: Parameter to account for the uncertain signal expectation given a certain cross-section
+
+  er_band_shift:
+    nominal_value: 0
+    ptype: shape
+    uncertainty: 'stats.uniform(loc=-2, scale=4)'
+    # relative_uncertainty: false
+    fittable: true
+    blueice_anchors:
+      - -2
+      - -1
+      - 0
+      - 1
+      - 2
+    fit_limits:
+      - -2
+      - 2
+    description: ER band shape parameter (shifts the ER band up and down)
+
+likelihood_config:
+  likelihood_weights: [1, 1, 1]
+  template_folder: null  # will try to find the templates in alea
+  likelihood_terms:
+    # SR0
+    - name: sr0
+      default_source_class: alea.template_source.TemplateSource
+      likelihood_type: blueice.likelihood.UnbinnedLogLikelihood
+      analysis_space:
+        - cs1: np.linspace(0, 100, 51)
+        - cs2: np.geomspace(100, 100000, 51)
+      in_events_per_bin: true
+      livetime_parameter: livetime_sr0
+      slice_args: {}
+      sources:
+      - name: er
+        histname: er_template  # TODO: implement a default histname based on the source name
+        parameters:
+          - er_rate_multiplier
+          - er_band_shift
+        named_parameters:
+          - er_band_shift
+        template_filename: er_template_{er_band_shift}.ii.h5
+        histogram_scale_factor: 1
+
+      - name: wimp
+        histname: wimp_template
+        parameters:
+          - wimp_mass
+          - wimp_rate_multiplier
+          - signal_efficiency
+        named_parameters:
+          - wimp_mass
+        template_filename: wimp{wimp_mass:d}gev_template.ii.h5
+        apply_efficiency: True
+        efficiency_name: signal_efficiency
+
+    # SR1
+    - name: sr1
+      default_source_class: alea.template_source.TemplateSource
+      likelihood_type: blueice.likelihood.UnbinnedLogLikelihood
+      analysis_space:
+        - cs1: np.linspace(0, 100, 51)
+        - cs2: np.geomspace(100, 100000, 51)
+      in_events_per_bin: true
+      livetime_parameter: livetime_sr1
+      slice_args: {}
+      sources:
+      - name: er
+        histname: er_template
+        parameters:
+          - er_rate_multiplier
+          - er_band_shift
+        named_parameters:
+          - er_band_shift
+        template_filename: er_template_{er_band_shift}.ii.h5
+        histogram_scale_factor: 2
+
+      - name: wimp
+        histname: wimp_template
+        parameters:
+          - wimp_mass
+          - wimp_rate_multiplier
+          - signal_efficiency
+        named_parameters:
+          - wimp_mass
+        template_filename: wimp{wimp_mass:d}gev_template.ii.h5
+        apply_efficiency: True
+        efficiency_name: signal_efficiency

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -440,42 +440,30 @@ class Parameters:
     @property
     def fit_guesses(self) -> Dict[str, float]:
         """A dictionary of fit guesses."""
-        ret = {}
-        for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param)
-            if param.fit_guess is not None:
-                ret[name] = param.fit_guess
-        return ret
+        return {
+            name: param.fit_guess
+            for name, param in self.parameters.items()
+            if param.fit_guess is not None
+        }
 
     @property
     def fit_limits(self) -> Dict[str, float]:
         """A dictionary of fit limits."""
-        ret = {}
-        for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param)
-            if param.fit_limits is not None:
-                ret[name] = param.fit_limits
-        return ret
+        return {
+            name: param.fit_limits
+            for name, param in self.parameters.items()
+            if param.fit_limits is not None
+        }
 
     @property
     def fittable(self) -> List[str]:
         """A list of parameter names which are fittable."""
-        ret = []
-        for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param)
-            if param.fittable:
-                ret.append(name)
-        return ret
+        return [name for name, param in self.parameters.items() if param.fittable]
 
     @property
     def not_fittable(self) -> List[str]:
         """A list of parameter names which are not fittable."""
-        ret = []
-        for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param)
-            if not param.fittable:
-                ret.append(name)
-        return ret
+        return [name for name, param in self.parameters.items() if not param.fittable]
 
     @property
     def uncertainties(self) -> dict:
@@ -484,12 +472,7 @@ class Parameters:
         Caution: this is not the same as the parameter.uncertainty property.
 
         """
-        ret = {}
-        for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param)
-            if param.uncertainty is not None:
-                ret[name] = param.uncertainty
-        return ret
+        return {k: i.uncertainty for k, i in self.parameters.items() if i.uncertainty is not None}
 
     @property
     def with_uncertainty(self) -> "Parameters":
@@ -499,11 +482,7 @@ class Parameters:
         For conditional parameters, the parameters under the nominal condition are returned.
 
         """
-        param_dict = {}
-        for k, i in self.parameters.items():
-            param = self._evaluate_conditional_parameters(i)
-            if param.uncertainty is not None:
-                param_dict[k] = param
+        param_dict = {k: i for k, i in self.parameters.items() if i.uncertainty is not None}
         params = Parameters()
         for param in param_dict.values():
             params.add_parameter(param)
@@ -512,12 +491,9 @@ class Parameters:
     @property
     def nominal_values(self) -> dict:
         """A dict of nominal values for all parameters with a nominal value."""
-        ret = {}
-        for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param)
-            if param.nominal_value is not None:
-                ret[name] = param.nominal_value
-        return ret
+        return {
+            k: i.nominal_value for k, i in self.parameters.items() if i.nominal_value is not None
+        }
 
     def set_nominal_values(self, **nominal_values):
         """Set the nominal values for parameters.

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -415,7 +415,15 @@ class Parameters:
         """Return an overview table of all parameters."""
         par_list = []
         for p in self:
-            par_dict = {}
+            if isinstance(p, ConditionalParameter):
+                par_dict = {
+                    "conditioning_name": p.conditioning_name,
+                    "conditions": sorted(p.conditions_dict.keys()),
+                }
+                # get nominal-condition parameter
+                p = p()
+            else:
+                par_dict = {}
             for k, v in p.__dict__.items():
                 # replace hidden attributes with non-hidden properties
                 if k.startswith("_"):

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -247,6 +247,56 @@ class ConditionalParameter():
 
         return conditions_dict
 
+    @property
+    def uncertainty(self) -> Any:
+        """Return the uncertainty of the parameter (nom. condition)"""
+        return self().uncertainty
+
+    @property
+    def blueice_anchors(self) -> Any:
+        """Return the blueice_anchors of the parameter (nom. condition)"""
+        return self().blueice_anchors
+
+    @property
+    def fit_guess(self) -> Optional[float]:
+        """Return the initial guess for fitting the parameter (nom. condition)"""
+        return self().fit_guess
+
+    @property
+    def parameter_interval_bounds(self) -> Optional[Tuple[float, float]]:
+        """Return the parameter_interval_bounds of the parameter (nom. condition)"""
+        return self().parameter_interval_bounds
+
+    @property
+    def nominal_value(self) -> Optional[float]:
+        """Return the nominal value of the parameter (nom. condition)"""
+        return self().nominal_value
+
+    @property
+    def needs_reinit(self) -> bool:
+        """Return True if the parameter needs re-initialization (for ptype ``needs_reinit``)."""
+        return self().needs_reinit
+
+    @property
+    def fittable(self) -> bool:
+        """Return the fittable attribute of the parameter (nom. condition)"""
+        return self().fittable
+
+    @property
+    def ptype(self) -> Optional[str]:
+        """Return the ptype of the parameter (nom. condition)"""
+        return self().ptype
+
+    @property
+    def relative_uncertainty(self) -> Optional[bool]:
+        """Return the relative_uncertainty of the parameter (nom. condition)"""
+        return self().relative_uncertainty
+
+    @property
+    def fit_limits(self) -> Optional[Tuple[float, float]]:
+        """Return the fit_limits of the parameter (nom. condition)"""
+        return self().fit_limits
+
     def __call__(self, **kwargs) -> Parameter:
         if self.conditioning_name in kwargs:
             cond_val = kwargs[self.conditioning_name]
@@ -446,16 +496,14 @@ class Parameters:
         """Return parameters with a not-NaN uncertainty.
 
         The parameters are the same objects as in the original Parameters object, not a copy.
-        For conditional parameters, the uncertainty is evaluated with the nominal value of the
-        conditioning parameter and the conditional parameter is added to the returned Parameters
-        in case the uncertainty of the nominal value is not None.
+        For conditional parameters, the parameters under the nominal condition are returned.
 
         """
         param_dict = {}
         for k, i in self.parameters.items():
-            evaluated_param = self._evaluate_conditional_parameters(i)
-            if evaluated_param.uncertainty is not None:
-                param_dict[k] = i
+            param = self._evaluate_conditional_parameters(i)
+            if param.uncertainty is not None:
+                param_dict[k] = param
         params = Parameters()
         for param in param_dict.values():
             params.add_parameter(param)
@@ -495,6 +543,7 @@ class Parameters:
         if isinstance(parameter, ConditionalParameter):
             new_cond_val = kwargs.get(parameter.conditioning_name, None)
             if new_cond_val is None:
+                print(self.parameters.keys())
                 new_cond_val = self.parameters[parameter.conditioning_name].nominal_value
             call_args = {parameter.conditioning_name: new_cond_val}
             return parameter(**call_args)

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -515,14 +515,9 @@ class Parameters:
         for name, value in fit_guesses.items():
             self.parameters[name].fit_guess = value
 
-    def _evaluate_conditional_parameters(self, parameter: Parameter, **kwargs):
+    def _evaluate_parameter(self, parameter: Parameter, **kwargs):
         if isinstance(parameter, ConditionalParameter):
-            new_cond_val = kwargs.get(parameter.conditioning_name, None)
-            if new_cond_val is None:
-                print(self.parameters.keys())
-                new_cond_val = self.parameters[parameter.conditioning_name].nominal_value
-            call_args = {parameter.conditioning_name: new_cond_val}
-            return parameter(**call_args)
+            return parameter(**kwargs)
         return parameter
 
     def __call__(
@@ -553,7 +548,7 @@ class Parameters:
                 raise ValueError(f"Parameter '{name}' not found.")
 
         for name, param in self.parameters.items():
-            param = self._evaluate_conditional_parameters(param, **kwargs)
+            param = self._evaluate_parameter(param, **kwargs)
             new_val = kwargs.get(name, None)
             if param.needs_reinit and new_val != param.nominal_value and new_val is not None:
                 raise ValueError(
@@ -627,7 +622,7 @@ class Parameters:
 
         """
         for name, value in kwargs.items():
-            param = self._evaluate_conditional_parameters(self.parameters[name], **kwargs)
+            param = self._evaluate_parameter(self.parameters[name], **kwargs)
             if not param.value_in_fit_limits(value):
                 return False
         return True

--- a/alea/parameters.py
+++ b/alea/parameters.py
@@ -306,8 +306,7 @@ class ConditionalParameter:
         """Return True if all attributes are equal."""
         if isinstance(other, ConditionalParameter):
             return all(getattr(self, k) == getattr(other, k) for k in self.__dict__)
-        else:
-            return False
+        return False
 
     def value_in_fit_limits(self, value: float) -> bool:
         """Returns True if value under cominal condition is within fit_limits."""

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -8,8 +8,7 @@ from alea.parameters import Parameters
 class TestParameters(TestCase):
     """Test of the Parameters class."""
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """Initialise the Parameters instance."""
         filenames = [
             "unbinned_wimp_statistical_model.yaml",
@@ -18,12 +17,12 @@ class TestParameters(TestCase):
         configs = []
         for fn in filenames:
             configs.append(load_yaml(fn)["parameter_definition"])
-        cls.configs = configs
+        self.configs = configs
 
         parameters_list = []
-        for config in cls.configs:
+        for config in self.configs:
             parameters_list.append(Parameters.from_config(config))
-        cls.parameters_list = parameters_list
+        self.parameters_list = parameters_list
 
     def test_from_list(self):
         """Test of the from_list method."""
@@ -47,7 +46,7 @@ class TestParameters(TestCase):
             if deepcopy(parameters) != parameters:
                 raise ValueError("Parameters instance cannot be correctly deepcopied.")
 
-    def test_ConditionalParameter(self):
+    def test_conditional_parameter(self):
         """Test of the ConditionalParameter class."""
         config = self.configs[1]
         parameters = self.parameters_list[1]

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -27,7 +27,7 @@ class TestParameters(TestCase):
     def test_from_list(self):
         """Test of the from_list method."""
         for config, parameters in zip(self.configs, self.parameters_list):
-            only_name_parameters = Parameters.from_list(config["parameter_definition"].keys())
+            only_name_parameters = Parameters.from_list(config.keys())
             # it is false because only names are assigned
             self.assertFalse(only_name_parameters == parameters)
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -11,24 +11,63 @@ class TestParameters(TestCase):
     @classmethod
     def setUp(cls):
         """Initialise the Parameters instance."""
-        cls.config = load_yaml("unbinned_wimp_statistical_model.yaml")
-        cls.parameters = Parameters.from_config(cls.config["parameter_definition"])
+        filenames = [
+            "unbinned_wimp_statistical_model.yaml",
+            "unbinned_wimp_statistical_model_mass_dependent_efficiency.yaml",
+        ]
+        configs = []
+        for fn in filenames:
+            configs.append(load_yaml(fn)["parameter_definition"])
+        cls.configs = configs
+
+        parameters_list = []
+        for config in cls.configs:
+            parameters_list.append(Parameters.from_config(config))
+        cls.parameters_list = parameters_list
 
     def test_from_list(self):
         """Test of the from_list method."""
-        only_name_parameters = Parameters.from_list(self.config["parameter_definition"].keys())
-        # it is false because only names are assigned
-        self.assertFalse(only_name_parameters == self.parameters)
+        for config, parameters in zip(self.configs, self.parameters_list):
+            only_name_parameters = Parameters.from_list(config["parameter_definition"].keys())
+            # it is false because only names are assigned
+            self.assertFalse(only_name_parameters == parameters)
 
     def test___repr__(self):
         """Test of the __repr__ method."""
-        for p in self.parameters:
-            if not isinstance(repr(p), str):
-                raise ValueError("The __repr__ method does not return the correct string.")
-        if not isinstance(repr(self.parameters), str):
-            raise TypeError("The __repr__ method does not return a string.")
+        for parameters in self.parameters_list:
+            for p in parameters:
+                if not isinstance(repr(p), str):
+                    raise ValueError("The __repr__ method does not return the correct string.")
+            if not isinstance(repr(parameters), str):
+                raise TypeError("The __repr__ method does not return a string.")
 
     def test_deep_copyable(self):
         """Test of whether Parameters instance can be deepcopied."""
-        if deepcopy(self.parameters) != self.parameters:
-            raise ValueError("Parameters instance cannot be correctly deepcopied.")
+        for parameters in self.parameters_list:
+            if deepcopy(parameters) != parameters:
+                raise ValueError("Parameters instance cannot be correctly deepcopied.")
+
+    def test_ConditionalParameter(self):
+        """Test of the ConditionalParameter class."""
+        config = self.configs[1]
+        parameters = self.parameters_list[1]
+        nominal_wimp_mass = config["wimp_mass"]["nominal_value"]
+        signal_eff_uncert_dict = config["signal_efficiency"]["uncertainty"]
+
+        # Directly accessing the property should return the value
+        # under nominal conditions
+        val = parameters.signal_efficiency.uncertainty
+        expected_val = signal_eff_uncert_dict[nominal_wimp_mass]
+        self.assertEqual(val, expected_val)
+
+        # Calling without kwargs should return the value
+        # under nominal conditions
+        val = parameters.signal_efficiency().uncertainty
+        expected_val = signal_eff_uncert_dict[nominal_wimp_mass]
+        self.assertEqual(val, expected_val)
+
+        # Calling with kwargs should return the value under
+        # the specified conditions
+        for wimp_mass, expected_val in signal_eff_uncert_dict.items():
+            val = parameters.signal_efficiency(wimp_mass=wimp_mass).uncertainty
+            self.assertEqual(val, expected_val)


### PR DESCRIPTION
This PR introduces conditional parameters.

### What's the problem?
In some cases, we want parameters to take different values depending on the value of other parameters.

One example is the WIMP-mass-dependent signal efficiency uncertainty. Here, we typically have larger uncertainties for lower masses. With conditional parameters, we can now simply add the following to our parameter definition in the config file:

```
wimp_mass:
    nominal_value: 50
    ...
signal_efficiency:
    conditioning_parameter_name: wimp_mass
    uncertainty:
      5: 0.3
      10: 0.2
      50: 0.15
      100: 0.1
      500: 0.1
    ...
```

Depending on the value of `wimp_mass` this will result in a different value of the `signal_efficiency` uncertainty.

### The ConditionalParameter class
Here's an example how the ConditionalParameter class works:

```python
from alea import load_yaml, Parameters


config_path = "%SOMEPATH%/alea/alea/examples/configs/unbinned_wimp_statistical_model_mass_dependent_efficiency.yaml"
config = load_yaml(config_path)

params = Parameters.from_config(config["parameter_definition"])

#  If you directly access a property of the conditional parameter, it will just return the
#  Parameter under nominal conditions (i.e. using the uncertainty for wimp_mass = 50)
print(params.signal_efficiency.uncertainty)
# >>> 0.15

#  The same happens if you call the conditional parameter without any arguments:
print(params.signal_efficiency().uncertainty)
# >>> 0.15

#  If you provide another value though, it will return the parameter for another wimp_mass:
print(params.signal_efficiency(wimp_mass=5).uncertainty)
# >>> 0.3

#  Another way to get there is to change the nominal value of wimp_mass:
params.wimp_mass.nominal_value = 5
print(params.signal_efficiency.uncertainty)
# >>> 0.3
```

### Caveat
So far, this doesn't work "on-the-fly" i.e. if I have a model instance and just change the `wimp_mass` value it won't correctly update the treatment of the signal efficiency since the likelihood is already initialized with the constraint terms. However, the structure introduced in this PR should allow introducing this feature in the future.

### What I tested so far
I tested this in a notebook for a few different WIMP masses (this won't work with the config in alea since we don't have any other WIMP mass templates yet, but you can ask me for an example notebook using actual templates). So far, everything looked good and behaved as expected but heavier testing with large toyMCs will follow.

Please have a look, play around with the new class, and let me know if something unexpected happens. Also, if you have any suggestions on how to implement this better, please let me know! In the meantime, I'll write some unittests and do some first checks with toyMCs.