### PR TITLE
Enable choosing the fit strategy

### DIFF
--- a/alea/examples/configs/unbinned_wimp_running.yaml
+++ b/alea/examples/configs/unbinned_wimp_running.yaml
@@ -66,13 +66,3 @@ htcondor_configurations:
   singularity_container: null
 
 outputfolder: null
-
-# just for illusrative purposes, the default values are shown here.
-# they are not needed in the configuration file but you could
-# overwrite them here.
-fit_strategy:
-  disable_index_fitting: False
-  max_index_fitting_iter: 10
-  minimizer_routine: "migrad"
-  minuit_strategy: 1
-  refit_invalid: True

--- a/alea/examples/configs/unbinned_wimp_running.yaml
+++ b/alea/examples/configs/unbinned_wimp_running.yaml
@@ -66,3 +66,13 @@ htcondor_configurations:
   singularity_container: null
 
 outputfolder: null
+
+# just for illusrative purposes, the default values are shown here.
+# they are not needed in the configuration file but you could
+# overwrite them here.
+fit_strategy:
+  disable_index_fitting: False
+  max_index_fitting_iter: 10
+  minimizer_routine: "migrad"
+  minuit_strategy: 1
+  refit_invalid: True

--- a/alea/examples/configs/unbinned_wimp_statistical_model.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model.yaml
@@ -136,3 +136,13 @@ likelihood_config:
         template_filename: wimp{wimp_mass:d}gev_template.ii.h5
         apply_efficiency: True
         efficiency_name: signal_efficiency
+
+# just for illusrative purposes, the default values are shown here.
+# they are not needed in the configuration file but you could
+# overwrite them here.
+fit_strategy:
+  disable_index_fitting: False
+  max_index_fitting_iter: 10
+  minimizer_routine: "migrad"
+  minuit_strategy: 1
+  refit_invalid: True

--- a/alea/model.py
+++ b/alea/model.py
@@ -107,9 +107,9 @@ class StatisticalModel:
         self._confidence_interval_kind = confidence_interval_kind
         self.confidence_interval_threshold = confidence_interval_threshold
         self.asymptotic_dof = asymptotic_dof
-        self.fit_strategy = _DEFAULT_FIT_STRATEGY
+        self._fit_strategy = _DEFAULT_FIT_STRATEGY
         if fit_strategy is not None:
-            self.fit_strategy.update(fit_strategy)
+            self._fit_strategy.update(fit_strategy)
         nominal_values = kwargs.get("nominal_values", None)
         self._define_parameters(parameter_definition, nominal_values)
 
@@ -371,7 +371,6 @@ class StatisticalModel:
         index_parameters = [
             p for p in self.parameters if p.ptype == "index" and p.name not in fixed_params
         ]
-
         if fit_strategy["disable_index_fitting"] or (len(index_parameters) == 0):
             m = self._standard_fit(m, fit_strategy["minimizer_routine"])
             if not m.valid and fit_strategy["refit_invalid"]:
@@ -396,14 +395,14 @@ class StatisticalModel:
     def _get_fit_strategy(self, fit_strategy) -> dict:
         # override the default fit strategy
         if fit_strategy is None:
-            fit_strategy = self.fit_strategy
+            fit_strategy = self._fit_strategy
         else:
             # check if keys are valid
             for key in fit_strategy.keys():
                 if key not in _DEFAULT_FIT_STRATEGY:
                     raise ValueError(f"Unknown key {key} in fit_strategy")
             # fill the gaps of fit_strategy with self.fit_strategy
-            for key, value in self.fit_strategy.items():
+            for key, value in self._fit_strategy.items():
                 fit_strategy.setdefault(key, value)
         return fit_strategy
 

--- a/alea/model.py
+++ b/alea/model.py
@@ -329,6 +329,10 @@ class StatisticalModel:
             max_index_fitting_iter (int): maximum number of iterations for index fitting
             minimizer_routine (str): the minimizer routine to use, either
                 "migrad", "simplex", or "simplex_migrad" (first run simplex, then migrad).
+            strategy (int): strategy for Minuit, can be 0, 1 (default), or 2. The higher the
+                number, the more precise the fit but also the slower it is.
+            refit_invalid (bool): if True, refit with the simplex_migrad routine
+                and strategy 2 if the optimization does not converge the first time.
 
         Returns:
             dict, float: best-fit values of each parameter,
@@ -561,6 +565,8 @@ class StatisticalModel:
                 volumes, where the global best-fit may not be along the profile.
                 If None, will be set to confidence_interval_args.
             asymptotic_dof (int, optional (default=None)): Degrees of freedom for asymptotic
+            fit_kwargs (dict, optional (default=None)): Additional keyword arguments
+                for the fit method
 
         """
         if confidence_interval_args is None:

--- a/alea/model.py
+++ b/alea/model.py
@@ -313,6 +313,7 @@ class StatisticalModel:
         disable_index_fitting=False,
         max_index_fitting_iter=10,
         minimizer_routine="migrad",
+        strategy=1,
         **kwargs,
     ) -> Tuple[dict, float]:
         """Fit the model to the data by maximizing the likelihood. Return a dict containing best-fit
@@ -345,6 +346,7 @@ class StatisticalModel:
         # Make the Minuit object
         m = Minuit(MinuitWrap(cost, parameters=self.parameters), **defaults)
         m.errordef = Minuit.LIKELIHOOD
+        m.strategy = strategy
         fixed_params = [] if fixed_parameters is None else fixed_parameters
         fixed_params += self.parameters.not_fittable
         for par in fixed_params:

--- a/alea/model.py
+++ b/alea/model.py
@@ -314,6 +314,7 @@ class StatisticalModel:
         max_index_fitting_iter=10,
         minimizer_routine="migrad",
         strategy=1,
+        refit_invalid=True,
         **kwargs,
     ) -> Tuple[dict, float]:
         """Fit the model to the data by maximizing the likelihood. Return a dict containing best-fit
@@ -359,6 +360,10 @@ class StatisticalModel:
 
         if disable_index_fitting or (len(index_parameters) == 0):
             m = self._standard_fit(m, minimizer_routine)
+            if not m.valid and refit_invalid:
+                # try to refit with more precision
+                m.strategy = 2
+                m = self._standard_fit(m, "simplex_migrad")
         else:
             m = self._index_mixing_fit(
                 m, index_parameters, max_index_fitting_iter, verbose, minimizer_routine

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -118,6 +118,10 @@ class Runner:
                 )
             parameter_definition = model_config["parameter_definition"]
             likelihood_config = model_config["likelihood_config"]
+            # in case of fit_strategy is provided in both
+            # statistical_model_config and arguments fit_strategy in
+            # arguments will overwrite fit_strategy in statistical_model_config
+            fit_strategy = {**model_config.get("fit_strategy", {}), **(fit_strategy or {})}
 
         # update nominal_values into statistical_model_args
         if statistical_model_args is None:

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -61,6 +61,8 @@ class Runner:
         confidence_level (float, optional (default=0.9)): confidence level
         confidence_interval_kind (str, optional (default='central')):
             kind of confidence interval, choice from 'central', 'upper' or 'lower'
+        fit_strategy (dict, optional (default=None)): fit strategy dictionary.
+            If None, the default fit strategy of the model will be used.
         toydata_mode (str, optional (default='generate_and_store')):
             toydata mode, choice from 'read', 'generate', 'generate_and_store', 'no_toydata'
         toydata_filename (str, optional (default=None)): toydata filename
@@ -87,6 +89,7 @@ class Runner:
         compute_confidence_interval: bool = False,
         confidence_level: float = 0.9,
         confidence_interval_kind: str = "central",
+        fit_strategy: Optional[dict] = None,
         toydata_mode: str = "generate_and_store",
         toydata_filename: str = "test_toydata_filename.ii.h5",
         only_toydata: bool = False,
@@ -131,6 +134,7 @@ class Runner:
             parameter_definition=parameter_definition,
             confidence_level=confidence_level,
             confidence_interval_kind=confidence_interval_kind,
+            fit_strategy=fit_strategy,
             **statistical_model_args,
         )
 

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -521,3 +521,4 @@ class Runner:
                 time.time() - global_start, time.process_time() - cpu_global_start
             )
         )
+        print("Alea iacta est.")

--- a/alea/submitter.py
+++ b/alea/submitter.py
@@ -73,6 +73,7 @@ class Submitter:
         computation_options: dict,
         computation: str = "discovery_power",
         outputfolder: Optional[str] = None,
+        fit_strategy: Optional[dict] = None,
         debug: bool = False,
         resubmit: bool = False,
         loglevel: str = "INFO",
@@ -100,6 +101,7 @@ class Submitter:
         self.statistical_model_config = statistical_model_config
         self.poi = poi
         self.outputfolder = outputfolder
+        self.fit_strategy = fit_strategy
 
         self.computation = computation
         self.computation_dict = computation_options[self.computation]
@@ -264,6 +266,7 @@ class Submitter:
             "statistical_model": self.statistical_model,
             "statistical_model_config": self.statistical_model_config,
             "poi": self.poi,
+            "fit_strategy": self.fit_strategy,
         }
 
         if set(merged_args_list[0].keys()) & set(common_runner_args.keys()):


### PR DESCRIPTION
### What's the issue?
In the past, we observed that sometimes, and under certain conditions, minuit might not find a "valid" minimum for the fit. There are a few different solutions to this issue:
 * Continue the fit with higher precision
 * Use a different minimizer routine to begin with
 * Increase fit precision to begin with

### What does this PR add?
In this PR, we enable choosing a fit strategy. For this, we add `_fit_strategy` attribute to the `StatisticalModel` class, which is used in the `fit()` and `confidence_interval()` method if not specified otherwise.
The `_fit_strategy` is a dictionary with the following entries:

| Entry | Functionality | Options |
|:-----|:---|:---|
|`minimizer_routine` (Default: `"migrad"`) | the minimizer routine to use | "migrad", "simplex", or "simplex_migrad" (first run simplex, then migrad) |
|`minuit_strategy` (Default: `1`) | "strategy" property of Minuit. The higher the number, the more precise the fit but also the slower. | 0, 1, or 2|
|`refit_invalid` (Default: `True`) | if True, refit with the `simplex_migrad` routine and strategy `2` if the optimization does not converge the first time.| True/False|
|`disable_index_fitting` (Default: `False`) |If True, disable the index fitting introduced in #156 even if the model has index parameters. | True/False|
|`max_index_fitting_iter` (Default: `10`) |Maximum number of iterations for index fitting | any integer|

The last two are not new but were direct arguments of the `fit` method before. 

There are a few ways to override the defaults on different levels:
 * Add `fit_strategy` with all/some overrides to your running config file and the strategy will be used for every computation of the runner
 * Initialize the statistical model with custom `fit_strategy` dict.
 * For an individual fit or confidence interval computation, pass a custom strategy to the method call. This can for example be used to compare performance and time requirements for different strategies before committing to one of them.

### How does the default behavior change?
The only difference in the default behavior is that invalid minima are now refit by default, which was not possible before. So far, the Minuit strategy was not specified and the Minuit default of 1 was used, which is the default also now. Also, the standard minimizer routine remains `migrad` as before.
