### PR TITLE
Defunctionalize `apply_efficiency`, apply efficiency when `efficiency_name` is specified

### DIFF
--- a/alea/examples/configs/unbinned_wimp_statistical_model.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model.yaml
@@ -101,7 +101,6 @@ likelihood_config:
         named_parameters:
           - wimp_mass
         template_filename: wimp{wimp_mass:d}gev_template.ii.h5
-        apply_efficiency: True
         efficiency_name: signal_efficiency
 
     # SR1
@@ -134,5 +133,4 @@ likelihood_config:
         named_parameters:
           - wimp_mass
         template_filename: wimp{wimp_mass:d}gev_template.ii.h5
-        apply_efficiency: True
         efficiency_name: signal_efficiency

--- a/alea/examples/configs/unbinned_wimp_statistical_model_template_source_test.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model_template_source_test.yaml
@@ -93,7 +93,6 @@ likelihood_config:
           - wimp_mass
           - signal_efficiency
         template_filename: wimp50gev_template.ii.h5
-        apply_efficiency: True
         efficiency_name: signal_efficiency
 
     # SR3, 1D inference on cS2 space
@@ -127,5 +126,4 @@ likelihood_config:
           - signal_efficiency
         template_filename: wimp50gev_template.ii.h5
         spectrum_name: test_cs1_spectrum.json
-        apply_efficiency: True
         efficiency_name: signal_efficiency

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -360,7 +360,7 @@ class BlueiceExtendedModel(StatisticalModel):
                     )
 
                 # set efficiency parameters
-                if not source.get("efficiency_name", None):
+                if source.get("efficiency_name", None):
                     self._set_efficiency(source, ll)
 
                 # set shape parameters

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -360,7 +360,7 @@ class BlueiceExtendedModel(StatisticalModel):
                     )
 
                 # set efficiency parameters
-                if source.get("apply_efficiency", False):
+                if not source.get("efficiency_name", None):
                     self._set_efficiency(source, ll)
 
                 # set shape parameters


### PR DESCRIPTION
This will kill the pain when people forget about `apply_efficiency`.