### PR TITLE
Trigger PyPI workflow on "published"

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -5,7 +5,7 @@ name: PyPI
 on:
   workflow_dispatch:
   release:
-    types: [ created ]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
For v0.2.4 and v0.2.5, the PyPI workflow was not triggered, probably because I saved the release as a draft before publishing it. Since we currently trigger the workflow on `created`, this is the intended behaviour as stated [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release). So solve this, I suggest triggering on `published` in the future (trigger on the following: "A release, pre-release, or draft of a release was published.").