### PR TITLE
Fix apply efficiency

### DIFF
--- a/alea/utils.py
+++ b/alea/utils.py
@@ -180,6 +180,8 @@ def adapt_likelihood_config_for_blueice(
                 get_file_path(template_filename, template_folder_list)
                 for template_filename in source["template_filenames"]
             ]
+        if source.get("efficiency_name", None):
+            source["apply_efficiency"] = True
         _prefix_file_path(source, template_folder_list)
     return likelihood_config_copy
 

--- a/tests/test_blueice_extended_model.py
+++ b/tests/test_blueice_extended_model.py
@@ -266,3 +266,12 @@ class TestBlueiceExtendedModel(TestCase):
             all_keys = {v for d in mus_per_ll.values() for v in d.keys()}
             all_keys = sorted(all_keys)
             self.assertEqual(all_keys, sorted(mus.keys()))
+
+    def test_apply_efficiency(self):
+        """Test if efficiencies are properly applied."""
+        model = self.models[0]
+        nominal_n = model.get_expectation_values()["wimp"]
+        for signal_eff in [0, 0.5, 1.0, 2.0]:
+            model.data = model.generate_data()
+            n = model.get_expectation_values(signal_efficiency=signal_eff)["wimp"]
+            self.assertEqual(n, nominal_n * signal_eff)


### PR DESCRIPTION
Turns out the `apply_efficiency` key, which was removed in #183 had a reason. It is propagated to blueice [here](https://github.com/JelleAalbers/blueice/blob/f12c2adffc0698e874a5fa25cbb7436fc5c58d54/blueice/likelihood.py#L83). If it is not provided, the efficiency is correctly added to the alea likelihood (since #183) but not taken into account in the likelihood evaluation.
This PR fixes this by automatically adding the key to the blueice config in case a `efficiency_name` is provided.