### PR TITLE
Tarball all needed templates from different folder

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -25,7 +25,7 @@ from Pegasus.api import (
 )
 from alea.runner import Runner
 from alea.submitter import Submitter
-from alea.utils import RECORDS, load_yaml, dump_yaml
+from alea.utils import TEMPLATE_RECORDS, load_yaml, dump_yaml
 
 
 DEFAULT_IMAGE = "/cvmfs/singularity.opensciencegrid.org/xenonnt/base-environment:latest"
@@ -70,7 +70,7 @@ class SubmitterHTCondor(Submitter):
         self.dagman_maxjobs = self.htcondor_configurations.pop("dagman_maxjobs", 100_000)
 
         super().__init__(*args, **kwargs)
-        RECORDS.lock()
+        TEMPLATE_RECORDS.lock()
 
         # Job input configurations
         self.config_file_path = os.path.abspath(self.config_file_path)
@@ -135,7 +135,7 @@ class SubmitterHTCondor(Submitter):
 
     def _make_template_tarball(self):
         """Make tarball of the templates if not exists."""
-        if not RECORDS.uniqueness:
+        if not TEMPLATE_RECORDS.uniqueness:
             raise RuntimeError("All files in the template path must have unique basenames.")
         os.makedirs(self.templates_tarball_dir, exist_ok=True)
         if os.listdir(self.templates_tarball_dir):
@@ -145,7 +145,7 @@ class SubmitterHTCondor(Submitter):
             )
 
         logger.info(f"Copying templates into {self.templates_tarball_dir}")
-        for record in tqdm(RECORDS):
+        for record in tqdm(TEMPLATE_RECORDS):
             # Copy each file to the destination folder
             shutil.copy(record, self.templates_tarball_dir)
         self._tar_h5_files(self.templates_tarball_dir, self.template_tarball)

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -95,7 +95,7 @@ METADATA=$(echo "$metadata" | sed "s/'/\"/g")
 mkdir -p templates
 START=$(date +%s)
 for TAR in `ls *.tar.gz`; do
-    tar -xzf $TAR -C templates
+    tar -xzf $TAR -C templates --strip-components=1
 done
 rm *.tar.gz
 END=$(date +%s)

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -66,7 +66,7 @@ class LockableSet(set):
         return [os.path.basename(record) for record in self]
 
 
-RECORDS = LockableSet()
+TEMPLATE_RECORDS = LockableSet()
 
 
 class ReadOnlyDict:
@@ -171,7 +171,7 @@ def _prefix_file_path(
         if isinstance(config[key], str) and key not in ignore_keys:
             try:
                 config[key] = get_file_path(config[key], template_folder_list)
-                RECORDS.update(glob(formatted_to_asterisked(config[key])))
+                TEMPLATE_RECORDS.update(glob(formatted_to_asterisked(config[key])))
             except RuntimeError:
                 pass
 


### PR DESCRIPTION
as long as their names are different

Asking all templates are in the same folder does not make sense, configuration like: https://github.com/XENONnT/nton/blob/fcccf25d583e1ee218724c4962d6fac9583c5191/nton/wimp/configs/sr0_sr1/wimp_statistical_model_ac_optimization.yaml#L409 and https://github.com/XENONnT/nton/blob/fcccf25d583e1ee218724c4962d6fac9583c5191/nton/wimp/configs/sr0_sr1/wimp_statistical_model_ac_optimization.yaml#L553 should be allowed.

1. Add a class `LockableSet` and initialize a variable `TEMPLATE_RECORDS` in `alea/utils.py`
2. Update `TEMPLATE_RECORDS` in `alea.utils._prefix_file_path`, so `TEMPLATE_RECORDS` will record all needed templates absolute path
3. Then we do not need `alea.submitters.htcondor.SubmitterHTCondor._validate_template_path` or `alea.submitters.htcondor.SubmitterHTCondor._check_filename_unique` any more
4. In `alea.submitters.htcondor.SubmitterHTCondor._tar_h5_files`, first copy all templates into `templates_tarball_dir` then make tarball of `templates_tarball_dir`