### PR TITLE
Fix the path of `alea_run_toymc` script

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -387,7 +387,7 @@ class SubmitterHTCondor(Submitter):
         rc.add_replica(
             "local",
             "alea_run_toymc",
-            "file://{}".format(self.top_dir / "bin/alea_run_toymc"),
+            "file://{}".format(self.top_dir / "alea/scripts/alea_run_toymc.py"),
         )
         # Add combine executable
         self.f_combine = File("combine.sh")

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -104,14 +104,13 @@ echo "Untarring took $DIFF seconds."
 
 # Source the environment
 . /opt/XENONnT/setup.sh
-chmod +x alea_run_toymc
 echo "Before running the toy MC, the work directory contains:"
 ls -lh
 echo "These are the contents of templates/:"
 ls -lh templates/
 
 # Print the command
-echo "Running command: python3 ./alea_run_toymc \\
+echo "Running command: python3 ./alea_run_toymc.py \\
     --statistical_model $STATISTICAL_MODEL \\
     --poi $POI \\
     --hypotheses $HYPOTHESES \\


### PR DESCRIPTION
A further fix of https://github.com/XENONnT/alea/pull/210.