### PR TITLE
Revert "Keep only one `Directory.SHARED_SCRATCH`"

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -84,6 +84,7 @@ class SubmitterHTCondor(Submitter):
         self.generated_dir = os.path.join(self.workflow_dir, "generated")
         self.runs_dir = os.path.join(self.workflow_dir, "runs")
         self.outputs_dir = os.path.join(self.workflow_dir, "outputs")
+        self.scratch_dir = os.path.join(self.workflow_dir, "scratch")
         self.templates_tarball_dir = os.path.join(self.generated_dir, "templates")
 
     @property
@@ -211,12 +212,15 @@ class SubmitterHTCondor(Submitter):
         # Local site: this is the submit host
         logger.debug("Defining local site")
         local = Site("local")
+        # Logs and pegasus output goes here. This place is called stash in OSG jargon.
+        scratch_dir = Directory(Directory.SHARED_SCRATCH, path=self.scratch_dir)
+        scratch_dir.add_file_servers(FileServer(f"file:///{self.scratch_dir}", Operation.ALL))
         # Jobs outputs goes here, but note that it is in scratch so it only stays for short term
         # This place is called stash in OSG jargon.
         storage_dir = Directory(Directory.LOCAL_STORAGE, path=self.outputs_dir)
         storage_dir.add_file_servers(FileServer(f"file:///{self.outputs_dir}", Operation.ALL))
         # Add scratch and storage directories to the local site
-        local.add_directories(storage_dir)
+        local.add_directories(scratch_dir, storage_dir)
         # Add profiles to the local site
         local.add_profiles(Namespace.ENV, HOME=os.environ["HOME"])
         local.add_profiles(Namespace.ENV, GLOBUS_LOCATION="")


### PR DESCRIPTION
Reverts XENONnT/alea#222

So my statement in the previous PR is incorrect: https://github.com/XENONnT/alea/pull/222#issue-2560049008.

Otherwise, we will see errors when job submission like:

```
Pegasus.client._client.PegasusClientError: Pegasus command: ['/usr/bin/pegasus-plan', '-Dpegasus.metrics.app=XENON', '-Dpegasus.data.configuration=nonsharedfs', '-Ddagman.retry=0', '-Ddagman.maxidle=100000', '-Ddagman.maxjobs=100000', '-Dpegasus.transfer.threads=4', '-Dpegasus.monitord.encoding=json', '-Dpegasus.catalog.workflow.amqp.url=amqp://friend:donatedata@msgs.pegasus.isi.edu:5672/prod/workflows', '--cluster', 'horizontal', '--sites', 'condorpool', '--output-sites', 'local', '--staging-site', 'condorpool=staging-davs', '--dir', '/scratch/xudc/workflows/wimp_ac_optimization-discovery_power-202410021020', '--relative-dir', 'runs', '--cleanup', 'none', '--submit', '/scratch/xudc/workflows/wimp_ac_optimization-discovery_power-202410021020/generated/workflow.yml', '--json'] FAILED
```