### PR TITLE
Add the workflow id to the folder in staging-davs

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -217,10 +217,10 @@ class SubmitterHTCondor(Submitter):
         scratch_dir.add_file_servers(FileServer(f"file:///{self.scratch_dir}", Operation.ALL))
         # Jobs outputs goes here, but note that it is in scratch so it only stays for short term
         # This place is called stash in OSG jargon.
-        storage_dir = Directory(Directory.LOCAL_STORAGE, path=self.outputs_dir)
-        storage_dir.add_file_servers(FileServer(f"file:///{self.outputs_dir}", Operation.ALL))
+        outputs_dir = Directory(Directory.LOCAL_STORAGE, path=self.outputs_dir)
+        outputs_dir.add_file_servers(FileServer(f"file:///{self.outputs_dir}", Operation.ALL))
         # Add scratch and storage directories to the local site
-        local.add_directories(scratch_dir, storage_dir)
+        local.add_directories(scratch_dir, outputs_dir)
         # Add profiles to the local site
         local.add_profiles(Namespace.ENV, HOME=os.environ["HOME"])
         local.add_profiles(Namespace.ENV, GLOBUS_LOCATION="")
@@ -245,13 +245,11 @@ class SubmitterHTCondor(Submitter):
         # You will be able to download results from there via gfal commands
         logger.debug("Defining stagging site")
         staging_davs = Site("staging-davs")
-        scratch_dir = Directory(
-            Directory.SHARED_SCRATCH, path=f"/xenon/scratch/{getpass.getuser()}"
-        )
+        scratch_dir_path = f"/xenon/scratch/{getpass.getuser()}/{self.workflow_id}"
+        scratch_dir = Directory(Directory.SHARED_SCRATCH, path=scratch_dir_path)
         scratch_dir.add_file_servers(
             FileServer(
-                "gsidavs://xenon-gridftp.grid.uchicago.edu:2880"
-                f"/xenon/scratch/{getpass.getuser()}",
+                f"gsidavs://xenon-gridftp.grid.uchicago.edu:2880{scratch_dir_path}",
                 Operation.ALL,
             )
         )


### PR DESCRIPTION
This will prevent output/scratch files related to different workflows putting in the same folder and being hard to distinguish.

Suggested in [slack thread](https://xenonnt.slack.com/archives/C048FE2U3KN/p1727117756578409?thread_ts=1726926843.149369&cid=C048FE2U3KN), sorry it has only internal access.