### PR TITLE
Add file hash to blueice hash

### DIFF
--- a/alea/utils.py
+++ b/alea/utils.py
@@ -700,6 +700,15 @@ def deterministic_hash(thing, length=10):
     return b32encode(digest)[:length].decode("ascii").lower()
 
 
+def compute_file_hash(file_path: str) -> str:
+    """Compute the SHA-256 hash of a file."""
+    hash_sha256 = sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_sha256.update(chunk)
+    return hash_sha256.hexdigest()
+
+
 def signal_multiplier_estimator(
     signal: np.ndarray,
     background: np.ndarray,

--- a/tests/test_template_source.py
+++ b/tests/test_template_source.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import shutil
+from inference_interface import template_to_multihist, multihist_to_template
 from alea.models import BlueiceExtendedModel
 from alea.utils import load_yaml
 
@@ -39,3 +41,48 @@ class TestTemplateSource(TestCase):
         space[1]["cs2"] = "np.geomspace(100, 100000, 51)"
         with self.assertRaises(ValueError):
             _ = BlueiceExtendedModel(parameter_definition, likelihood_config)
+
+    def test_hash_updates_on_template_change(self):
+        """Test whether the hash of the template changes when the file is modified."""
+        config_path = "unbinned_wimp_statistical_model_template_source_test.yaml"
+        model = BlueiceExtendedModel.from_config(config_path)
+
+        hash_er_sr2 = model.likelihood_list[0].base_model.sources[0].hash
+        hash_wimp_sr2 = model.likelihood_list[0].base_model.sources[1].hash
+        hash_er_sr3 = model.likelihood_list[1].base_model.sources[0].hash
+        hash_wimp_sr3 = model.likelihood_list[1].base_model.sources[1].hash
+
+        # modify one of the ER templates
+        path = model.likelihood_list[1].base_model.sources[0].config["templatename"]
+        path = path.format(er_band_shift=0)
+        backup_path = path + ".backup"
+        shutil.copy(path, backup_path)
+        h = template_to_multihist(path, "er_template")
+        h.histogram *= 2
+        multihist_to_template([h], path, ["er_template"])
+
+        # check that the hash of the ER sources has changed
+        model = BlueiceExtendedModel.from_config(config_path)
+        self.assertNotEqual(hash_er_sr2, model.likelihood_list[0].base_model.sources[0].hash)
+        self.assertNotEqual(hash_er_sr3, model.likelihood_list[1].base_model.sources[0].hash)
+        self.assertEqual(hash_wimp_sr2, model.likelihood_list[0].base_model.sources[1].hash)
+        self.assertEqual(hash_wimp_sr3, model.likelihood_list[1].base_model.sources[1].hash)
+        # restore the original template
+        shutil.move(backup_path, path)
+
+        # modify the WIMP template
+        path = model.likelihood_list[1].base_model.sources[1].config["templatename"]
+        backup_path = path + ".backup"
+        shutil.copy(path, backup_path)
+        h = template_to_multihist(path, "wimp_template")
+        h.histogram *= 2
+        multihist_to_template([h], path, ["wimp_template"])
+
+        # check that the hash of the WIMP sources has changed
+        model = BlueiceExtendedModel.from_config(config_path)
+        self.assertEqual(hash_er_sr2, model.likelihood_list[0].base_model.sources[0].hash)
+        self.assertEqual(hash_er_sr3, model.likelihood_list[1].base_model.sources[0].hash)
+        self.assertNotEqual(hash_wimp_sr2, model.likelihood_list[0].base_model.sources[1].hash)
+        self.assertNotEqual(hash_wimp_sr3, model.likelihood_list[1].base_model.sources[1].hash)
+        # restore the original template
+        shutil.move(backup_path, path)


### PR DESCRIPTION
So far, if you made changes to a template that was already cached by blueice, blueice would use the cached version instead of the new one. This PR solves this issue by computing the hash of each source's template file and adding it to the blueice source config.