### PR TITLE
Fix livetime bug in get_expectation_values()

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -196,7 +196,7 @@ class BlueiceExtendedModel(StatisticalModel):
         ):
             ret[ll_name] = {}
             ll_index = self.likelihood_names.index(ll_name)
-            lt = generate_values.pop(lt_name, None)
+            lt = generate_values.get(lt_name, None)
             # compute the mus
             self.data_generators[ll_index].compute_pdfs_and_mus(**generate_values, livetime_days=lt)
             mus = self.data_generators[ll_index].mus


### PR DESCRIPTION
This fixes a very dumb bug in the `get_expectation_value` method of the `BlueiceExtendedModel`. So far, the lifetime was popped from the `generate_values`, which meant that if two or more terms used the same livetime parameter, the value would only be used for the first one.