### PR TITLE
Add unused needs_reinit parameters to ignored parameters

### DIFF
--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -305,7 +305,8 @@ class BlueiceExtendedModel(StatisticalModel):
         parameters_to_ignore: List[str] = [
             p.name
             for p in self.parameters
-            if (p.ptype in ["shape", "index"]) and (p.name not in source["parameters"])
+            if (p.ptype in ["shape", "index", "needs_reinit"])
+            and (p.name not in source["parameters"])
         ]
         # no efficiency affects PDF:
         parameters_to_ignore += [p.name for p in self.parameters if (p.ptype == "efficiency")]


### PR DESCRIPTION
This is another tiny PR to improve the template caching behavior.

So far, we specify all `shape` and `index` parameters that are not used by a source in the `dont_hash_settings`. However, wit this we're missing shape parameters such as the WIMP mass, which is usually implemented as a `needs_reinit` parameter. By including it now we can reduce the number of duplicated cached histograms.