### PR TITLE
Tar user-installed blueice to osg nodes

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -397,7 +397,8 @@ class SubmitterHTCondor(Submitter):
                 # Packages should not be non-editable user-installed
                 if Tarball.is_user_installed(package_name):
                     raise RuntimeError(
-                        f"You should install {package_name} in non-editable user-installed mode."
+                        f"You should not install {package_name} in "
+                        "non-editable user-installed mode."
                     )
             else:
                 _tarball.create_tarball()

--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -391,7 +391,7 @@ class SubmitterHTCondor(Submitter):
         """Make tarballs of Ax-based packages if they are in editable user-installed mode."""
         tarballs = []
         tarball_paths = []
-        for package_name in ["alea"]:
+        for package_name in ["alea", "blueice"]:
             _tarball = Tarball(self.generated_dir, package_name)
             if not Tarball.get_installed_git_repo(package_name):
                 # Packages should not be non-editable user-installed

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -92,8 +92,7 @@ SEED=$(echo "$seed" | sed "s/'/\"/g")
 METADATA=$(echo "$metadata" | sed "s/'/\"/g")
 
 # Installing customized packages
-. install.sh alea
-. install.sh blueice
+. install.sh alea blueice
 
 # Extract tarballs input
 mkdir -p templates

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -93,6 +93,7 @@ METADATA=$(echo "$metadata" | sed "s/'/\"/g")
 
 # Installing customized packages
 . install.sh alea
+. install.sh blueice
 
 # Extract tarballs input
 mkdir -p templates


### PR DESCRIPTION
Similar to alea, this now tars and installs a user-installed version of blueice to osg computing nodes.