### PR TITLE
Fix bug, only add tarball when git installed

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -407,8 +407,8 @@ class SubmitterHTCondor(Submitter):
                 logger.warning(
                     f"Using tarball of user installed package {package_name} at {tarball_path}."
                 )
-            tarballs.append(tarball)
-            tarball_paths.append(tarball_path)
+                tarballs.append(tarball)
+                tarball_paths.append(tarball_path)
         return tarballs, tarball_paths
 
     def _initialize_job(


### PR DESCRIPTION
Otherwise, you will see error like:

```
Traceback (most recent call last):
  File "/home/xudc/alea/alea/scripts/alea_submission.py", line 99, in <module>
    main()
  File "/home/xudc/alea/alea/scripts/alea_submission.py", line 95, in main
    submitter.submit()
  File "/home/xudc/alea/alea/submitters/htcondor.py", line 700, in submit
    self._generate_workflow()
  File "/home/xudc/alea/alea/submitters/htcondor.py", line 585, in _generate_workflow
    job.add_inputs(
  File "/usr/lib64/pegasus/python/Pegasus/api/_utils.py", line 85, in wrapper
    assert f(self, *args, **kwargs) == None
  File "/usr/lib64/pegasus/python/Pegasus/api/workflow.py", line 88, in add_inputs
    raise DuplicateError(
Pegasus.api.errors.DuplicateError: file: alea.tar.gz has already been added as input to this job
```