### PR TITLE
Update blueice dependence

### DIFF
--- a/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
+++ b/alea/examples/configs/unbinned_wimp_statistical_model_index_fitting.yaml
@@ -54,6 +54,7 @@ likelihood_config:
     - name: science_run
       default_source_class: alea.template_source.TemplateSource
       likelihood_type: blueice.likelihood.UnbinnedLogLikelihood
+      source_wise_interpolation: false
       likelihood_config: {"morpher": "IndexMorpher"}
       analysis_space:
         - cs1: np.arange(0, 102, 2)

--- a/alea/models/blueice_extended_model.py
+++ b/alea/models/blueice_extended_model.py
@@ -296,9 +296,16 @@ class BlueiceExtendedModel(StatisticalModel):
         # get blueice likelihood_config if it's given
         likelihood_config = config.get("likelihood_config", None)
 
+        source_wise_interpolation = config.get("source_wise_interpolation", True)
+
+        if source_wise_interpolation and likelihood_config:
+            if likelihood_config.get("morpher") == "IndexMorpher":
+                raise ValueError("Source-wise interpolation is not yet supported for IndexMorpher.")
+
         blueice_config = {
             "pdf_base_config": pdf_base_config,
             "likelihood_config": likelihood_config,
+            "source_wise_interpolation": source_wise_interpolation,
         }
         return blueice_config
 
@@ -335,7 +342,6 @@ class BlueiceExtendedModel(StatisticalModel):
         # Iterate through each likelihood term in the configuration
         for config in likelihood_config["likelihood_terms"]:
             blueice_config = self._process_blueice_config(config, template_folder_list)
-            blueice_config.setdefault("source_wise_interpolation", True)
 
             likelihood_class = cast(Callable, locate(config["likelihood_type"]))
             if likelihood_class is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ alea_submission = "alea.scripts.alea_submission:main"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
 atomicwrites = "*"
-blueice = "*"
+blueice = ">=1.2.1"
 h5py = "*"
 inference-interface = "*"
 iminuit = ">=2.21.0"


### PR DESCRIPTION
This updates blueice dependence to require version 1.2.1, which includes the source-wise interpolation.