### PR TITLE
Install only the `user_install_package`

### DIFF
--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -71,6 +71,11 @@ class SubmitterHTCondor(Submitter):
         self.dagman_maxidle = self.htcondor_configurations.pop("dagman_maxidle", 100_000)
         self.dagman_maxjobs = self.htcondor_configurations.pop("dagman_maxjobs", 100_000)
 
+        # Self-installed packages
+        self.package_names = self.htcondor_configurations.pop(
+            "user_install_package", ["alea", "blueice"]
+        )
+
         super().__init__(*args, **kwargs)
         TEMPLATE_RECORDS.lock()
 
@@ -389,9 +394,10 @@ class SubmitterHTCondor(Submitter):
 
     def make_tarballs(self):
         """Make tarballs of Ax-based packages if they are in editable user-installed mode."""
+        self.user_install_package = []
         tarballs = []
         tarball_paths = []
-        for package_name in ["alea", "blueice"]:
+        for package_name in self.package_names:
             _tarball = Tarball(self.generated_dir, package_name)
             if not Tarball.get_installed_git_repo(package_name):
                 # Packages should not be non-editable user-installed
@@ -407,6 +413,7 @@ class SubmitterHTCondor(Submitter):
                 logger.warning(
                     f"Using tarball of user installed package {package_name} at {tarball_path}."
                 )
+                self.user_install_package.append(package_name)
                 tarballs.append(tarball)
                 tarball_paths.append(tarball_path)
         return tarballs, tarball_paths
@@ -446,6 +453,10 @@ class SubmitterHTCondor(Submitter):
         )
         job.add_profiles(Namespace.CONDOR, "request_disk", disk_str)
         job.add_profiles(Namespace.CONDOR, "request_memory", memory_str)
+
+        # User installed packages
+        user_install_package = " ".join(self.user_install_package)
+        job.add_profiles(Namespace.ENV, "USER_INSTALL_PACKAGE", user_install_package)
 
         return job
 

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -92,7 +92,7 @@ SEED=$(echo "$seed" | sed "s/'/\"/g")
 METADATA=$(echo "$metadata" | sed "s/'/\"/g")
 
 # Installing customized packages
-. install.sh alea blueice
+. install.sh $USER_INSTALL_PACKAGE
 
 # Extract tarballs input
 mkdir -p templates


### PR DESCRIPTION
Copied from https://github.com/XENONnT/outsource/pull/314

If setting a list of packages in `user_install_package` in `htcondor_configurations` in the running configuration, the packages will be first checked and installed on OSG computing nodes if necessary (if editable installed by `pip --user`).

If nothing is set, by default `["alea", "blueice"]` will be set as the `user_install_package`.

```
htcondor_configurations:
  user_install_package: ["alea", "blueice"]
```