### PR TITLE
Modifications to Enable OSG Submissions for CES Jobs

### DIFF
--- a/alea/runner.py
+++ b/alea/runner.py
@@ -182,7 +182,9 @@ class Runner:
             )
         # update poi according to poi_expectation
         if "poi_expectation" in value:
-            value = self.update_poi(self.model, self.poi, value, self.nominal_values, self.poi_is_rate_multiplier)
+            value = self.update_poi(
+                self.model, self.poi, value, self.nominal_values, self.poi_is_rate_multiplier
+            )
         return value
 
     @property
@@ -239,7 +241,11 @@ class Runner:
 
     @staticmethod
     def update_poi(
-        model, poi: str, generate_values: Dict[str, float], nominal_values: Dict[str, float] = {}, poi_is_rate_multiplier: bool = False,
+        model,
+        poi: str,
+        generate_values: Dict[str, float],
+        nominal_values: Dict[str, float] = {},
+        poi_is_rate_multiplier: bool = False,
     ):
         """Update the poi according to poi_expectation. First, it will check if poi_expectation is
         provided, if not so, it will do nothing. Second, it will check if poi is provided, if so, it
@@ -252,8 +258,8 @@ class Runner:
             generate_values (dict): generate values of toydata,
                 it can contain "poi_expectation"
             nominal_values (dict): nominal values of parameters
-            poi_is_rate_multiplier (bool): whether the poi is a rate multiplier, default is False, 
-                False: the input unit is number of events. 
+            poi_is_rate_multiplier (bool): whether the poi is a rate multiplier, default is False,
+                False: the input unit is number of events.
                 True: the input unit is rate multiplier.
 
         Caution:
@@ -273,7 +279,7 @@ class Runner:
                 "the generate_values according to the expectations."
             )
         poi_expectation = generate_values.pop("poi_expectation")
-        
+
         if poi_is_rate_multiplier:
             # Direct assignment: poi_expectation is already the rate_multiplier value
             generate_values[poi] = poi_expectation
@@ -286,7 +292,7 @@ class Runner:
             component = poi.replace("_rate_multiplier", "")
             nominal_expectation = expectation_values[component]
             ratio = poi_expectation / nominal_expectation
-            generate_values[poi] = ratio 
+            generate_values[poi] = ratio
         return generate_values
 
     def _get_parameter_list(self):

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -77,6 +77,7 @@ class Runner:
         self,
         statistical_model: str = "alea.examples.gaussian_model.GaussianModel",
         poi: str = "mu",
+        poi_is_rate_multiplier: bool = False,
         hypotheses: list = ["free"],
         n_mc: int = 1,
         common_hypothesis: Optional[dict] = None,
@@ -99,6 +100,7 @@ class Runner:
     ):
         """Initialize statistical model, parameters list, and generate values list."""
         self.poi = poi
+        self.poi_is_rate_multiplier = poi_is_rate_multiplier
 
         statistical_model_class = StatisticalModel.get_model_from_name(statistical_model)
 
@@ -180,7 +182,7 @@ class Runner:
             )
         # update poi according to poi_expectation
         if "poi_expectation" in value:
-            value = self.update_poi(self.model, self.poi, value, self.nominal_values)
+            value = self.update_poi(self.model, self.poi, value, self.nominal_values, self.poi_is_rate_multiplier)
         return value
 
     @property
@@ -237,7 +239,7 @@ class Runner:
 
     @staticmethod
     def update_poi(
-        model, poi: str, generate_values: Dict[str, float], nominal_values: Dict[str, float] = {}
+        model, poi: str, generate_values: Dict[str, float], nominal_values: Dict[str, float] = {}, poi_is_rate_multiplier: bool = False,
     ):
         """Update the poi according to poi_expectation. First, it will check if poi_expectation is
         provided, if not so, it will do nothing. Second, it will check if poi is provided, if so, it
@@ -250,6 +252,9 @@ class Runner:
             generate_values (dict): generate values of toydata,
                 it can contain "poi_expectation"
             nominal_values (dict): nominal values of parameters
+            poi_is_rate_multiplier (bool): whether the poi is a rate multiplier, default is False, 
+                False: the input unit is number of events. 
+                True: the input unit is rate multiplier.
 
         Caution:
             The expectation is evaluated under nominal_values in each batch.
@@ -267,18 +272,21 @@ class Runner:
                 "if poi_expectation is provided, because you want to update "
                 "the generate_values according to the expectations."
             )
-        generate_values_copy = deepcopy(generate_values)
-        generate_values_copy.pop("poi_expectation")
-        expectation_values = model.get_expectation_values(
-            **{**generate_values_copy, **nominal_values}
-        )
-        component = poi.replace("_rate_multiplier", "")
-        nominal_expectation = expectation_values[component]
-        poi_expectation = generate_values["poi_expectation"]
-        ratio = poi_expectation / nominal_expectation
-        # update poi to the correct value
-        generate_values.pop("poi_expectation")
-        generate_values[poi] = ratio
+        poi_expectation = generate_values.pop("poi_expectation")
+        
+        if poi_is_rate_multiplier:
+            # Direct assignment: poi_expectation is already the rate_multiplier value
+            generate_values[poi] = poi_expectation
+        else:
+            # Original logic: poi_expectation is number of events, need to normalize
+            generate_values_copy = deepcopy(generate_values)
+            expectation_values = model.get_expectation_values(
+                **{**generate_values_copy, **nominal_values}
+            )
+            component = poi.replace("_rate_multiplier", "")
+            nominal_expectation = expectation_values[component]
+            ratio = poi_expectation / nominal_expectation
+            generate_values[poi] = ratio 
         return generate_values
 
     def _get_parameter_list(self):

--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -179,7 +179,11 @@ class SubmitterHTCondor(Submitter):
         def update_template_filenames(node):
             if isinstance(node, dict):
                 for key, value in node.items():
-                    if key in ["template_filename", "template_filenames", "spectrum_name"]:  # specific keys
+                    if key in [
+                        "template_filename",
+                        "template_filenames",
+                        "spectrum_name",
+                    ]:  # specific keys
                         if isinstance(value, list):  # list case
                             node[key] = [os.path.basename(v) for v in value]
                         else:  # single file case

--- a/alea/submitters/htcondor.py
+++ b/alea/submitters/htcondor.py
@@ -179,9 +179,11 @@ class SubmitterHTCondor(Submitter):
         def update_template_filenames(node):
             if isinstance(node, dict):
                 for key, value in node.items():
-                    if key in ["template_filename", "spectrum_name"]:
-                        filename = os.path.basename(value)
-                        node[key] = filename
+                    if key in ["template_filename", "template_filenames", "spectrum_name"]:  # specific keys
+                        if isinstance(value, list):  # list case
+                            node[key] = [os.path.basename(v) for v in value]
+                        else:  # single file case
+                            node[key] = os.path.basename(value)
                     else:
                         update_template_filenames(value)
             elif isinstance(node, list):

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -30,7 +30,7 @@ toydata_filename=${18}
 only_toydata=${19}
 output_filename=${20}
 seed=${21}
-metadata=${22} 
+metadata=${22}
 echo "statistical_model: $statistical_model"
 echo "poi: $poi"
 echo "hypotheses: $hypotheses"

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Check if number of arguments passed is correct
-if [ $# -ne 21 ]; then
+if [ $# -ne 22 ]; then
     echo "Error: You need to provide required number of arguments."
     exit 1
 fi
@@ -11,25 +11,26 @@ fi
 # Extract the arguments
 statistical_model=$1
 poi=$2
-hypotheses=$3
-n_mc=$4
-common_hypothesis=$5
-generate_values=$6
-nominal_values=$7
-statistical_model_config=$8
-parameter_definition=$9
-statistical_model_args=${10}
-likelihood_config=${11}
-compute_confidence_interval=${12}
-confidence_level=${13}
-confidence_interval_kind=${14}
-fit_strategy=${15}
-toydata_mode=${16}
-toydata_filename=${17}
-only_toydata=${18}
-output_filename=${19}
-seed=${20}
-metadata=${21}
+poi_is_rate_multiplier=$3
+hypotheses=$4
+n_mc=$5
+common_hypothesis=$6
+generate_values=$7
+nominal_values=$8
+statistical_model_config=$9
+parameter_definition=${10}
+statistical_model_args=${11}
+likelihood_config=${12}
+compute_confidence_interval=${13}
+confidence_level=${14}
+confidence_interval_kind=${15}
+fit_strategy=${16}
+toydata_mode=${17}
+toydata_filename=${18}
+only_toydata=${19}
+output_filename=${20}
+seed=${21}
+metadata=${22} 
 echo "statistical_model: $statistical_model"
 echo "poi: $poi"
 echo "hypotheses: $hypotheses"
@@ -71,6 +72,7 @@ fi
 # Escaped strings
 STATISTICAL_MODEL=$(echo "$statistical_model" | sed "s/'/\"/g")
 POI=$(echo "$poi" | sed "s/'/\"/g")
+POI_IS_RATE_MULTIPLIER=$(echo "$poi_is_rate_multiplier" | sed "s/'/\"/g")
 HYPOTHESES=$(echo "$hypotheses" | sed "s/'/\"/g")
 N_MC=$(echo "$n_mc" | sed "s/'/\"/g")
 COMMON_HYPOTHESIS=$(echo "$common_hypothesis" | sed "s/'/\"/g")
@@ -116,6 +118,7 @@ ls -lh templates/
 echo "Running command: python alea_run_toymc.py \\
     --statistical_model $STATISTICAL_MODEL \\
     --poi $POI \\
+    --poi_is_rate_multiplier $POI_IS_RATE_MULTIPLIER \\
     --hypotheses $HYPOTHESES \\
     --n_mc $N_MC \\
     --common_hypothesis $COMMON_HYPOTHESIS \\
@@ -140,6 +143,7 @@ echo "Running command: python alea_run_toymc.py \\
 time python alea_run_toymc.py \
     --statistical_model $STATISTICAL_MODEL \
     --poi $POI \
+    --poi_is_rate_multiplier $POI_IS_RATE_MULTIPLIER \
     --hypotheses $HYPOTHESES \
     --n_mc $N_MC \
     --common_hypothesis $COMMON_HYPOTHESIS \


### PR DESCRIPTION
## Summary of Changes

This PR introduces two modifications to enhance flexibility and correctness when handling CES jobs and POI configurations:

---

### 1. Support for `template_filenames` as a List in `htcondor.py`

- **Context**: In CES jobs, some sources use a mixed spectrum composed as a weighted average of multiple histograms.
- **Issue**: The `template_filenames` field can be a list rather than a single string, but the original `update_template_filenames()` function did not support this.
- **Solution**: The function now checks if the value is a list and applies `os.path.basename()` to each entry. This ensures consistent filename extraction for both string and list inputs.

---

### 2. Add `poi_is_rate_multiplier` Flag to `alea_run_toymc`

- **Context**: The original POI logic assumes the POI is the absolute number of observed events (used in WIMP searches).
- **Issue**: For CES studies, the expected event count is normalized differently — typically in units of event/ton/year. In such cases, the POI should directly represent a rate multiplier, not a raw count.
- **Solution**: Introduced a new boolean flag `poi_is_rate_multiplier`:
  - `False` (default): POI is treated as the number of events (original behavior).
  - `True`: POI is treated directly as a rate multiplier.
- **Changes**:
  - Modified CLI (`run_toymc_wrapper.sh`) to include the new argument.
  - Updated `alea/runner.py` and internal logic to propagate and respect the flag.

---

### Additional Notes

- Both changes are **non-breaking** and fully **backward-compatible**.
- These enhancements are necessary to enable `alea`’s support for CES-specific workflows

### Test
The PR is already tested with the [config files](https://github.com/XENONnT/LowERAnalysis/tree/master/data/submission_config) in the LowER repo. Note that it should be used with [utilix v0.11.2](https://github.com/XENONnT/utilix/releases/tag/v0.11.2). 
In order to test, run:
`alea_submission solarpp_running.yaml --computation discovery_power --htcondor`
