### PR TITLE
Revert poi rate multiplier and toymc wrapper changes

### DIFF
--- a/alea/runner.py
+++ b/alea/runner.py
@@ -77,7 +77,6 @@ class Runner:
         self,
         statistical_model: str = "alea.examples.gaussian_model.GaussianModel",
         poi: str = "mu",
-        poi_is_rate_multiplier: bool = False,
         hypotheses: list = ["free"],
         n_mc: int = 1,
         common_hypothesis: Optional[dict] = None,
@@ -100,7 +99,6 @@ class Runner:
     ):
         """Initialize statistical model, parameters list, and generate values list."""
         self.poi = poi
-        self.poi_is_rate_multiplier = poi_is_rate_multiplier
 
         statistical_model_class = StatisticalModel.get_model_from_name(statistical_model)
 
@@ -182,9 +180,7 @@ class Runner:
             )
         # update poi according to poi_expectation
         if "poi_expectation" in value:
-            value = self.update_poi(
-                self.model, self.poi, value, self.nominal_values, self.poi_is_rate_multiplier
-            )
+            value = self.update_poi(self.model, self.poi, value, self.nominal_values)
         return value
 
     @property
@@ -241,11 +237,7 @@ class Runner:
 
     @staticmethod
     def update_poi(
-        model,
-        poi: str,
-        generate_values: Dict[str, float],
-        nominal_values: Dict[str, float] = {},
-        poi_is_rate_multiplier: bool = False,
+        model, poi: str, generate_values: Dict[str, float], nominal_values: Dict[str, float] = {}
     ):
         """Update the poi according to poi_expectation. First, it will check if poi_expectation is
         provided, if not so, it will do nothing. Second, it will check if poi is provided, if so, it
@@ -258,9 +250,6 @@ class Runner:
             generate_values (dict): generate values of toydata,
                 it can contain "poi_expectation"
             nominal_values (dict): nominal values of parameters
-            poi_is_rate_multiplier (bool): whether the poi is a rate multiplier, default is False,
-                False: the input unit is number of events.
-                True: the input unit is rate multiplier.
 
         Caution:
             The expectation is evaluated under nominal_values in each batch.
@@ -278,21 +267,18 @@ class Runner:
                 "if poi_expectation is provided, because you want to update "
                 "the generate_values according to the expectations."
             )
-        poi_expectation = generate_values.pop("poi_expectation")
-
-        if poi_is_rate_multiplier:
-            # Direct assignment: poi_expectation is already the rate_multiplier value
-            generate_values[poi] = poi_expectation
-        else:
-            # Original logic: poi_expectation is number of events, need to normalize
-            generate_values_copy = deepcopy(generate_values)
-            expectation_values = model.get_expectation_values(
-                **{**generate_values_copy, **nominal_values}
-            )
-            component = poi.replace("_rate_multiplier", "")
-            nominal_expectation = expectation_values[component]
-            ratio = poi_expectation / nominal_expectation
-            generate_values[poi] = ratio
+        generate_values_copy = deepcopy(generate_values)
+        generate_values_copy.pop("poi_expectation")
+        expectation_values = model.get_expectation_values(
+            **{**generate_values_copy, **nominal_values}
+        )
+        component = poi.replace("_rate_multiplier", "")
+        nominal_expectation = expectation_values[component]
+        poi_expectation = generate_values["poi_expectation"]
+        ratio = poi_expectation / nominal_expectation
+        # update poi to the correct value
+        generate_values.pop("poi_expectation")
+        generate_values[poi] = ratio
         return generate_values
 
     def _get_parameter_list(self):

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Check if number of arguments passed is correct
-if [ $# -ne 22 ]; then
+if [ $# -ne 21 ]; then
     echo "Error: You need to provide required number of arguments."
     exit 1
 fi
@@ -11,26 +11,25 @@ fi
 # Extract the arguments
 statistical_model=$1
 poi=$2
-poi_is_rate_multiplier=$3
-hypotheses=$4
-n_mc=$5
-common_hypothesis=$6
-generate_values=$7
-nominal_values=$8
-statistical_model_config=$9
-parameter_definition=${10}
-statistical_model_args=${11}
-likelihood_config=${12}
-compute_confidence_interval=${13}
-confidence_level=${14}
-confidence_interval_kind=${15}
-fit_strategy=${16}
-toydata_mode=${17}
-toydata_filename=${18}
-only_toydata=${19}
-output_filename=${20}
-seed=${21}
-metadata=${22}
+hypotheses=$3
+n_mc=$4
+common_hypothesis=$5
+generate_values=$6
+nominal_values=$7
+statistical_model_config=$8
+parameter_definition=$9
+statistical_model_args=${10}
+likelihood_config=${11}
+compute_confidence_interval=${12}
+confidence_level=${13}
+confidence_interval_kind=${14}
+fit_strategy=${15}
+toydata_mode=${16}
+toydata_filename=${17}
+only_toydata=${18}
+output_filename=${19}
+seed=${20}
+metadata=${21}
 echo "statistical_model: $statistical_model"
 echo "poi: $poi"
 echo "hypotheses: $hypotheses"
@@ -72,7 +71,6 @@ fi
 # Escaped strings
 STATISTICAL_MODEL=$(echo "$statistical_model" | sed "s/'/\"/g")
 POI=$(echo "$poi" | sed "s/'/\"/g")
-POI_IS_RATE_MULTIPLIER=$(echo "$poi_is_rate_multiplier" | sed "s/'/\"/g")
 HYPOTHESES=$(echo "$hypotheses" | sed "s/'/\"/g")
 N_MC=$(echo "$n_mc" | sed "s/'/\"/g")
 COMMON_HYPOTHESIS=$(echo "$common_hypothesis" | sed "s/'/\"/g")
@@ -118,7 +116,6 @@ ls -lh templates/
 echo "Running command: python alea_run_toymc.py \\
     --statistical_model $STATISTICAL_MODEL \\
     --poi $POI \\
-    --poi_is_rate_multiplier $POI_IS_RATE_MULTIPLIER \\
     --hypotheses $HYPOTHESES \\
     --n_mc $N_MC \\
     --common_hypothesis $COMMON_HYPOTHESIS \\
@@ -143,7 +140,6 @@ echo "Running command: python alea_run_toymc.py \\
 time python alea_run_toymc.py \
     --statistical_model $STATISTICAL_MODEL \
     --poi $POI \
-    --poi_is_rate_multiplier $POI_IS_RATE_MULTIPLIER \
     --hypotheses $HYPOTHESES \
     --n_mc $N_MC \
     --common_hypothesis $COMMON_HYPOTHESIS \


### PR DESCRIPTION
In #255 we had two modifications to enable the support for CES job submissions on OSG. But thanks to @dachengx, I now realize that the `poi_is_rate_multiplier` is redundant. The use of `poi` is just a special case in the WIMP config. More generally, we can set `generate_values` directly in the config to change the rate multipliers directly. 

Thererfore, we revert the changes for the `poi_is_rate_multiplier` implementation, while keeping the handling for `template_filenames`