### PR TITLE
Add argument `confidence_interval_root_find` indicating root finding method

### DIFF
--- a/alea/model.py
+++ b/alea/model.py
@@ -75,6 +75,7 @@ class StatisticalModel:
             threshold for confidence interval
         confidence_interval_root_find (str, optional (default="brentq")):
             root finding algorithm of confidence interval
+            supported options: "brentq" and "extremal"
         data (dict or list, optional (default=None)): pre-set data of the model
         fit_strategy (dict, optional (default=None)): strategy for the fit,
             see _DEFAULT_FIT_STRATEGY for possible settings
@@ -503,6 +504,7 @@ class StatisticalModel:
                 kind of confidence interval to compute
             confidence_interval_root_find (str, optional (default=None)):
                 root finding algorithm of confidence interval
+                supported options: "brentq" and "extremal"
 
         Returns:
             Tuple[str, Callable[[float], float], str, Tuple[float, float]]:
@@ -608,6 +610,7 @@ class StatisticalModel:
                 If None, the default kind of the model is used.
             confidence_interval_root_find (str, optional (default=None)):
                 root finding algorithm of confidence interval
+                supported options: "brentq" and "extremal"
             confidence_interval_args (dict, optional (default=None)): Parameters that will be fixed
                 in the profile likelihood computation. If None, all fittable parameters
                 will be profiled except the poi.

--- a/alea/model.py
+++ b/alea/model.py
@@ -12,7 +12,13 @@ from blueice.likelihood import _needs_data
 from inference_interface import toydata_to_file
 
 from alea.parameters import Parameters
-from alea.utils import within_limits, clip_limits, asymptotic_critical_value, ReadOnlyDict
+from alea.utils import (
+    within_limits,
+    clip_limits,
+    asymptotic_critical_value,
+    ReadOnlyDict,
+    extremal_root,
+)
 
 _DEFAULT_FIT_STRATEGY = {
     "disable_index_fitting": False,
@@ -67,6 +73,8 @@ class StatisticalModel:
             kind of confidence interval to compute
         confidence_interval_threshold (Callable[[float], float], optional (default=None)):
             threshold for confidence interval
+        confidence_interval_root_find (str, optional (default="brentq")):
+            root finding algorithm of confidence interval
         data (dict or list, optional (default=None)): pre-set data of the model
         fit_strategy (dict, optional (default=None)): strategy for the fit,
             see _DEFAULT_FIT_STRATEGY for possible settings
@@ -81,8 +89,9 @@ class StatisticalModel:
         self,
         parameter_definition: Optional[Union[dict, list]] = None,
         confidence_level: float = 0.9,
-        confidence_interval_kind: str = "central",  # one of central, upper, lower
+        confidence_interval_kind: str = "central",  # one of central, upper, and lower
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
+        confidence_interval_root_find: str = "brentq",  # one of brentq and extremal
         asymptotic_dof: Optional[int] = 1,
         data: Optional[Union[dict, list]] = None,
         fit_strategy: Optional[dict] = None,
@@ -103,9 +112,12 @@ class StatisticalModel:
             self.data = data
         self._confidence_level = confidence_level
         if confidence_interval_kind not in {"central", "upper", "lower"}:
-            raise ValueError("confidence_interval_kind must be one of central, upper, lower")
+            raise ValueError("confidence_interval_kind must be one of central, upper, and lower")
         self._confidence_interval_kind = confidence_interval_kind
         self.confidence_interval_threshold = confidence_interval_threshold
+        if confidence_interval_root_find not in {"brentq", "extremal"}:
+            raise ValueError("confidence_interval_root_find must be one of brentq and extremal")
+        self._confidence_interval_root_find = confidence_interval_root_find
         self.asymptotic_dof = asymptotic_dof
         self._fit_strategy = _DEFAULT_FIT_STRATEGY
         if fit_strategy is not None:
@@ -475,9 +487,10 @@ class StatisticalModel:
         confidence_level: Optional[float] = None,
         confidence_interval_kind: Optional[str] = None,
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
+        confidence_interval_root_find: Optional[str] = None,
         asymptotic_dof: Optional[int] = None,
         **kwargs,
-    ) -> Tuple[str, Callable[[float], float], Tuple[float, float]]:
+    ) -> Tuple[str, Callable[[float], float], str, Tuple[float, float]]:
         """Helper function for confidence_interval that does the input checks and return bounds.
 
         Args:
@@ -488,9 +501,11 @@ class StatisticalModel:
                 confidence level for confidence intervals
             confidence_interval_kind (str, optional (default=None)):
                 kind of confidence interval to compute
+            confidence_interval_root_find (str, optional (default=None)):
+                root finding algorithm of confidence interval
 
         Returns:
-            Tuple[str, Callable[[float], float], Tuple[float, float]]:
+            Tuple[str, Callable[[float], float], str, Tuple[float, float]]:
                 confidence interval kind, confidence interval threshold, parameter interval bounds
 
         """
@@ -498,6 +513,8 @@ class StatisticalModel:
             confidence_level = self._confidence_level
         if confidence_interval_kind is None:
             confidence_interval_kind = self._confidence_interval_kind
+        if confidence_interval_root_find is None:
+            confidence_interval_root_find = self._confidence_interval_root_find
 
         if (confidence_level < 0) or (confidence_level > 1):
             raise ValueError("confidence_level must be between 0 and 1")
@@ -551,7 +568,12 @@ class StatisticalModel:
         if not callable(confidence_interval_threshold):
             raise ValueError("confidence_interval_threshold must be a callable")
 
-        return confidence_interval_kind, confidence_interval_threshold, parameter_interval_bounds
+        return (
+            confidence_interval_kind,
+            confidence_interval_threshold,
+            confidence_interval_root_find,
+            parameter_interval_bounds,
+        )
 
     def confidence_interval(
         self,
@@ -560,6 +582,7 @@ class StatisticalModel:
         confidence_level: Optional[float] = None,
         confidence_interval_kind: Optional[str] = None,
         confidence_interval_threshold: Optional[Callable[[float], float]] = None,
+        confidence_interval_root_find: Optional[str] = None,
         confidence_interval_args: Optional[dict] = None,
         best_fit_args: Optional[dict] = None,
         asymptotic_dof: Optional[int] = None,
@@ -583,6 +606,8 @@ class StatisticalModel:
             confidence_interval_kind (str, optional (default=None)):
                 kind of confidence interval to compute.
                 If None, the default kind of the model is used.
+            confidence_interval_root_find (str, optional (default=None)):
+                root finding algorithm of confidence interval
             confidence_interval_args (dict, optional (default=None)): Parameters that will be fixed
                 in the profile likelihood computation. If None, all fittable parameters
                 will be profiled except the poi.
@@ -606,12 +631,14 @@ class StatisticalModel:
             confidence_level,
             confidence_interval_kind,
             confidence_interval_threshold,
+            confidence_interval_root_find,
             asymptotic_dof,
             **confidence_interval_args,
         )
         (
             confidence_interval_kind,
             confidence_interval_threshold,
+            confidence_interval_root_find,
             parameter_interval_bounds,
         ) = ci_objects
 
@@ -650,7 +677,12 @@ class StatisticalModel:
 
         if confidence_interval_kind in {"upper", "central"} and t_best_parameter < 0:
             if t(parameter_interval_bounds[1]) > 0:
-                ul = brentq(t, best_parameter, parameter_interval_bounds[1])
+                if confidence_interval_root_find == "brentq":
+                    ul = brentq(t, best_parameter, parameter_interval_bounds[1])
+                elif confidence_interval_root_find == "extremal":
+                    ul = extremal_root(
+                        t, best_parameter, parameter_interval_bounds[1], which="left"
+                    )
             else:
                 ul = np.inf
         else:
@@ -658,7 +690,12 @@ class StatisticalModel:
 
         if confidence_interval_kind in {"lower", "central"} and t_best_parameter < 0:
             if t(parameter_interval_bounds[0]) > 0:
-                dl = brentq(t, parameter_interval_bounds[0], best_parameter)
+                if confidence_interval_root_find == "brentq":
+                    dl = brentq(t, parameter_interval_bounds[0], best_parameter)
+                elif confidence_interval_root_find == "extremal":
+                    dl = extremal_root(
+                        t, parameter_interval_bounds[0], best_parameter, which="right"
+                    )
             else:
                 dl = -1 * np.inf
         else:

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -61,6 +61,8 @@ class Runner:
         confidence_level (float, optional (default=0.9)): confidence level
         confidence_interval_kind (str, optional (default='central')):
             kind of confidence interval, choice from 'central', 'upper' or 'lower'
+        confidence_interval_root_find (str, optional (default='brentq')):
+            root finding algorithm of confidence interval
         fit_strategy (dict, optional (default=None)): fit strategy dictionary.
             If None, the default fit strategy of the model will be used.
         toydata_mode (str, optional (default='generate_and_store')):
@@ -89,6 +91,7 @@ class Runner:
         compute_confidence_interval: bool = False,
         confidence_level: float = 0.9,
         confidence_interval_kind: str = "central",
+        confidence_interval_root_find: str = "brentq",
         fit_strategy: Optional[dict] = None,
         toydata_mode: str = "generate_and_store",
         toydata_filename: str = "test_toydata_filename.ii.h5",
@@ -138,6 +141,7 @@ class Runner:
             parameter_definition=parameter_definition,
             confidence_level=confidence_level,
             confidence_interval_kind=confidence_interval_kind,
+            confidence_interval_root_find=confidence_interval_root_find,
             fit_strategy=fit_strategy,
             **statistical_model_args,
         )

--- a/alea/runner.py
+++ b/alea/runner.py
@@ -63,6 +63,7 @@ class Runner:
             kind of confidence interval, choice from 'central', 'upper' or 'lower'
         confidence_interval_root_find (str, optional (default='brentq')):
             root finding algorithm of confidence interval
+            supported options: "brentq" and "extremal"
         fit_strategy (dict, optional (default=None)): fit strategy dictionary.
             If None, the default fit strategy of the model will be used.
         toydata_mode (str, optional (default='generate_and_store')):

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -23,13 +23,14 @@ likelihood_config=${11}
 compute_confidence_interval=${12}
 confidence_level=${13}
 confidence_interval_kind=${14}
-fit_strategy=${15}
-toydata_mode=${16}
-toydata_filename=${17}
-only_toydata=${18}
-output_filename=${19}
-seed=${20}
-metadata=${21}
+confidence_interval_root_find=${15}
+fit_strategy=${16}
+toydata_mode=${17}
+toydata_filename=${18}
+only_toydata=${19}
+output_filename=${20}
+seed=${21}
+metadata=${22}
 echo "statistical_model: $statistical_model"
 echo "poi: $poi"
 echo "hypotheses: $hypotheses"
@@ -44,6 +45,7 @@ echo "likelihood_config: $likelihood_config"
 echo "compute_confidence_interval: $compute_confidence_interval"
 echo "confidence_level: $confidence_level"
 echo "confidence_interval_kind: $confidence_interval_kind"
+echo "confidence_interval_root_find: $confidence_interval_root_find"
 echo "fit_strategy: $fit_strategy"
 echo "toydata_mode: $toydata_mode"
 echo "toydata_filename: $toydata_filename"
@@ -83,6 +85,7 @@ LIKELIHOOD_CONFIG=$(echo "$likelihood_config" | sed "s/'/\"/g")
 COMPUTE_CONFIDENCE_INTERVAL=$(echo "$compute_confidence_interval" | sed "s/'/\"/g")
 CONFIDENCE_LEVEL=$(echo "$confidence_level" | sed "s/'/\"/g")
 CONFIDENCE_INTERVAL_KIND=$(echo "$confidence_interval_kind" | sed "s/'/\"/g")
+CONFIDENCE_INTERVAL_ROOT_FIND=$(echo "$confidence_interval_root_find" | sed "s/'/\"/g")
 FIT_STRATEGY=$(echo "$fit_strategy" | sed "s/'/\"/g")
 TOYDATA_MODE=$(echo "$toydata_mode" | sed "s/'/\"/g")
 TOYDATA_FILENAME=$(echo "$toydata_filename" | sed "s/'/\"/g")
@@ -128,6 +131,7 @@ echo "Running command: python alea_run_toymc.py \\
     --compute_confidence_interval $COMPUTE_CONFIDENCE_INTERVAL \\
     --confidence_level $CONFIDENCE_LEVEL \\
     --confidence_interval_kind $CONFIDENCE_INTERVAL_KIND \\
+    --confidence_interval_root_find $CONFIDENCE_INTERVAL_ROOT_FIND \\
     --fit_strategy $FIT_STRATEGY \\
     --toydata_mode $TOYDATA_MODE \\
     --toydata_filename $TOYDATA_FILENAME \\
@@ -152,6 +156,7 @@ time python alea_run_toymc.py \
     --compute_confidence_interval $COMPUTE_CONFIDENCE_INTERVAL \
     --confidence_level $CONFIDENCE_LEVEL \
     --confidence_interval_kind $CONFIDENCE_INTERVAL_KIND \
+    --confidence_interval_root_find $CONFIDENCE_INTERVAL_ROOT_FIND \
     --fit_strategy $FIT_STRATEGY \
     --toydata_mode $TOYDATA_MODE \
     --toydata_filename $TOYDATA_FILENAME \

--- a/alea/submitters/run_toymc_wrapper.sh
+++ b/alea/submitters/run_toymc_wrapper.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Check if number of arguments passed is correct
-if [ $# -ne 21 ]; then
+if [ $# -ne 22 ]; then
     echo "Error: You need to provide required number of arguments."
     exit 1
 fi

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -4,6 +4,7 @@ import json
 import yaml
 import itertools
 import blueice
+import warnings
 from glob import glob
 from copy import deepcopy
 from pydoc import locate
@@ -817,6 +818,14 @@ def extremal_root(
 
     if step_growth < 1.0:
         raise ValueError("step_growth must be larger than 1")
+
+    fraction = [1e-6, 0.1]
+    if step < fraction[0] * (xR - xL) or step > fraction[1] * (xR - xL):
+        warnings.warn(
+            f"The step {step} is either too small or too larger "
+            f"comparing to the given boundary [{xL}, {xR}]."
+            "Consider to redefine parameter_interval_bounds?"
+        )
 
     direction = +1 if which == "left" else -1
 

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -785,14 +785,38 @@ def extremal_root(
     xtol=1e-12,
     rtol=4 * np.finfo(float).eps,
 ):
-    """Find the left-most or right-most root of f in [xL, xR] using adaptive scanning + brentq
-    refinement."""
+    """Return the left-most or right-most root of `f` in [xL, xR].
+
+    The interval is scanned adaptively to detect a sign change, and the root
+    is refined using `scipy.optimize.brentq`.
+
+    Args:
+        f (Callable[[float], float]): Scalar function.
+        xL (float): Left boundary (must satisfy xR > xL).
+        xR (float): Right boundary.
+        which (str, optional): "left" or "right". Default is "left".
+        step (float, optional): Initial scan step (>0).
+        step_growth (float, optional): Step multiplier (>=1).
+        max_step (float | None, optional): Maximum scan step.
+        xtol (float, optional): Absolute tolerance for `brentq`.
+        rtol (float, optional): Relative tolerance for `brentq`.
+
+    Returns:
+        float: Extremal root in the interval.
+
+    """
 
     if xR <= xL:
         raise ValueError("Require xR > xL")
 
     if which not in {"left", "right"}:
         raise ValueError('which must be "left" or "right"')
+
+    if step <= 0:
+        raise ValueError("step must be larger than 0")
+
+    if step_growth < 1.0:
+        raise ValueError("step_growth must be larger than 1")
 
     direction = +1 if which == "left" else -1
 

--- a/alea/utils.py
+++ b/alea/utils.py
@@ -822,8 +822,10 @@ def extremal_root(
     fraction = [1e-6, 0.1]
     if step < fraction[0] * (xR - xL) or step > fraction[1] * (xR - xL):
         warnings.warn(
-            f"The step {step} is either too small or too larger "
-            f"comparing to the given boundary [{xL}, {xR}]."
+            f"The step size {step}'s fraction is either "
+            f"too small (smaller than {fraction[0]}) or "
+            f"too large (larger than {fraction[1]}) "
+            f"comparing to the given boundary [{xL}, {xR}]. "
             "Consider to redefine parameter_interval_bounds?"
         )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -38,6 +38,7 @@ class TestRunner(TestCase):
             nominal_values={"sigma": 1.0},
             parameter_definition=gaussian_model_parameter_definition,
             compute_confidence_interval=COMPUTE_CONFIDENCE_INTERVAL,
+            confidence_interval_root_find="extremal",
             toydata_mode=toydata_mode,
             toydata_filename=self.toydata_filename,
             output_filename=self.output_filename,


### PR DESCRIPTION
When calculating CL, if `confidence_interval_root_find` is `brentq`, use `scipy.optimize.brentq`; if `extremal`, look for the left or right-most root.

The left- right- most root finding is performed in `utils.extremal_root`. This function accepts almost the same arguments as `scipy.optimize.brentq`.