### PR TITLE
New CES template that bypasses energy smearing, bias and efficiency

### DIFF
--- a/alea/ces_source.py
+++ b/alea/ces_source.py
@@ -554,7 +554,7 @@ class CESFlatSource(CESTemplateSource):
             "bias": None,
             "efficiency": self._create_transformation("efficiency"),
         }
-        
+
 
 class CESTemplateWithoutDetectorResponse(CESTemplateSource):
     def _get_transformations(self):

--- a/alea/ces_source.py
+++ b/alea/ces_source.py
@@ -554,3 +554,13 @@ class CESFlatSource(CESTemplateSource):
             "bias": None,
             "efficiency": self._create_transformation("efficiency"),
         }
+        
+
+class CESTemplateWithoutDetectorResponse(CESTemplateSource):
+    def _get_transformations(self):
+        """Override detector response functions."""
+        return {
+            "smearing": None,
+            "bias": None,
+            "efficiency": None,
+        }


### PR DESCRIPTION
Some backgrounds have complicated event topologies, like beta-gamma cascades of Pb212/Pb214. Their spectrum can be derived via MC simulations, however, those inherently include the detector response already. For this reason I made a new template source that does not add the energy bias, energy smearing and efficiency to a template, otherwise they would be double-applied.