### PR TITLE
Add packages to pythonpath to overwrite env packages

### DIFF
--- a/alea/submitters/rcc_slurm.py
+++ b/alea/submitters/rcc_slurm.py
@@ -39,6 +39,7 @@ class SubmitterRCCSlurm(Submitter):
         self.slurm_configurations = kwargs.get("slurm_configurations", {})
         self.template_path = self.slurm_configurations.pop("template_path", None)
         self.combine_n_jobs = self.slurm_configurations.pop("combine_n_jobs", 1)
+        self.script_preamble = self.slurm_configurations.pop("script_preamble", "")
         self.batchq_arguments = {**BATCHQ_DEFAULT_ARGUMENTS, **self.slurm_configurations}
         self._check_batchq_arguments()
         super().__init__(*args, **kwargs)
@@ -54,6 +55,8 @@ class SubmitterRCCSlurm(Submitter):
             log (str): The path to the log file.
 
         """
+        if self.script_preamble:
+            job = self.script_preamble + "\n" + job
         jobname = kwargs.pop("jobname", None)
         if jobname is None:
             jobname = self.name

--- a/alea/submitters/slurm.py
+++ b/alea/submitters/slurm.py
@@ -35,6 +35,7 @@ class SubmitterSlurm(Submitter):
         self.slurm_configurations = kwargs.get("slurm_configurations", {})
         self.template_path = self.slurm_configurations.pop("template_path", None)
         self.combine_n_jobs = self.slurm_configurations.pop("combine_n_jobs", 1)
+        self.script_preamble = self.slurm_configurations.pop("script_preamble", "")
         self.batchq_arguments = {**BATCHQ_DEFAULT_ARGUMENTS, **self.slurm_configurations}
         super().__init__(*args, **kwargs)
 
@@ -49,6 +50,8 @@ class SubmitterSlurm(Submitter):
             log (str): The path to the log file.
 
         """
+        if self.script_preamble:
+            job = self.script_preamble + "\n" + job
         jobname = kwargs.pop("jobname", None)
         if jobname is None:
             jobname = self.name


### PR DESCRIPTION
Maybe useful when testing new features on a Slurm Submitter. Depending on how your environment is set up, the slurm submitter may always choose alea/blueice (or any other package in principle) that may be in it to submit your alea jobs which makes it difficult to test changes in alea itself with the slurm submitter. This simple addition lets you add the following line to your "slurm_configurations" dict to add things to PYTHONPATH during submission like
`
script_preamble: "export PYTHONPATH=<path_package1>:<path_package2>:<path_package3>:$PYTHONPATH"
`

Maybe there is an easier way to do this, but I've been using this and maybe someone else finds it useful :-D 